### PR TITLE
Rack does not need to be an explicit dependency.

### DIFF
--- a/gds-sso.gemspec
+++ b/gds-sso.gemspec
@@ -33,7 +33,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'warden', '~> 1.2'
   s.add_dependency 'omniauth-gds', '0.0.2'
   s.add_dependency 'rack-accept', '~> 0.4.4'
-  s.add_dependency "rack", '1.3.5'
 
   s.add_development_dependency 'rake',  '~> 0.9.2'
   s.add_development_dependency 'mocha', '~> 0.9.0'


### PR DESCRIPTION
The previous gemspec tied gds-sso to a particular version of rack.  This forces any app using gds-sso to use versions of rails that use this version of rack.  This prevents the use of versions that include serious security patches such as this: http://seclists.org/oss-sec/2012/q2/504.  There are other reasons to tie apps to a specific version of rack (passenger oddness) but I don't think this is the right place.

Note, as the gemspec still includes a dependency on rails, there is still an implicit rack dependency, which will change as the version of rails used changes.
