### PR TITLE
Skip authorisation for API users

### DIFF
--- a/lib/gds-sso/controller_methods.rb
+++ b/lib/gds-sso/controller_methods.rb
@@ -5,8 +5,10 @@ module GDS
       end
 
       def authorise_user!(scope, permission)
-        if not current_user.has_permission?(scope, permission)
-          raise PermissionDeniedException
+        if not GDS::SSO::ApiAccess.api_call?(request.env)
+          if not current_user.has_permission?(scope, permission)
+            raise PermissionDeniedException
+          end
         end
       end
 

--- a/spec/requests/end_to_end_spec.rb
+++ b/spec/requests/end_to_end_spec.rb
@@ -97,6 +97,13 @@ describe "Integration of client using GDS-SSO with signonotron" do
 
       page.should have_content('restricted kablooie')
     end
+
+    specify "access to a page that requires signin permission granted (without basic auth users having permissions)" do
+      page.driver.browser.authorize 'test_api_user', 'api_user_password'
+      visit "http://#{@client_host}/this_requires_signin_permission"
+
+      page.should have_content('you have signin permission')
+    end
   end
 
   def click_authorize


### PR DESCRIPTION
FAO @jystewart 

IMPORTANT: Note that the way this is implemented introduces a security vulnerability.
If you are authenticated in an app (i.e. you have the session cookie), you might craft
a request that sets the header that is used to determine whether or not this is an API
requst. You would then effectively be granted all permissions. If there is a way to
determine which strategy was used to authenticate, this vulnerability could be removed.

This code should not be very long-lived. Currently API users are authenticated with
basic auth, so there isn't a way to grant or read permissions for them. We plan to
switch API access to OAuth soon, at which point we can remove this.
