### PR TITLE
Expose permissions update API

### DIFF
--- a/app/controllers/api/user_controller.rb
+++ b/app/controllers/api/user_controller.rb
@@ -1,0 +1,31 @@
+class Api::UserController < ApplicationController
+  before_filter :authenticate_user!
+  before_filter :require_user_update_permission
+
+  def update
+    user_json = JSON.parse(request.body.read)['user']
+    oauth_hash = build_gds_oauth_hash(user_json)
+    GDS::SSO::Config.user_klass.find_for_gds_oauth(oauth_hash)
+    head :success
+  end
+
+  private
+    # This should mirror the object created by the omniauth-gds strategy/gem
+    # By doing this, we can reuse the code for creating/updating the user
+    def build_gds_oauth_hash(user_json)
+      OmniAuth::AuthHash.new(
+          uid: user_json['uid'], 
+          provider: 'gds', 
+          info: { 
+            name: user_json['name'], 
+            email: user_json['email']
+          }, 
+          extra: { 
+            user: { permissions: user_json['permissions'] }
+          })
+    end
+
+    def require_user_update_permission
+      authorise_user!(GDS::SSO::Config.default_scope, "user_update_permission")
+    end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,6 @@
 Rails.application.routes.draw do
   match '/auth/gds/callback', to: 'authentications#callback', as: :gds_sign_in
   match '/auth/gds/sign_out', to: 'authentications#sign_out', as: :gds_sign_out
-  match '/auth/failure',  to: 'authentications#failure',  as: :auth_failure
+  match '/auth/failure',      to: 'authentications#failure',  as: :auth_failure
+  match '/auth/gds/api/user', to: "api/user#update", via: "PUT"
 end

--- a/spec/controller/api_user_controller_spec.rb
+++ b/spec/controller/api_user_controller_spec.rb
@@ -1,0 +1,56 @@
+require "spec_helper"
+
+def user_update_json
+  {
+    "user" => { 
+      "uid" => "a1s2d3", 
+      "name" => "Joshua Marshall", 
+      "email" => "user@domain.com", 
+      "permissions" => {
+        "GDS_SSO integration test" => ["signin", "new permission"]
+      }
+    }
+  }.to_json
+end
+
+describe Api::UserController, type: :controller do
+
+  before :each do
+    @user_to_update = User.new({ 
+        :uid => 'a1s2d3', 
+        :name => "Moshua Jarshall", 
+        :permissions => { "GDS_SSO integration test" => ["signin"] } })
+  end
+
+  describe "PUT update" do
+    it "should deny access to anybody but the API user (or a user with 'user_update_permission')" do
+      malicious_user = User.new({ 
+          :uid => '2', 
+          :name => "User", 
+          :permissions => { "GDS_SSO integration test" => ["signin"] } })
+
+      request.env['warden'] = stub("stub warden", :authenticate! => true, authenticated?: true, user: malicious_user)
+
+      request.env['RAW_POST_DATA'] = user_update_json
+      put :update
+      
+      assert_equal 403, response.status
+    end
+
+    it "should create/update the user record in the same way as the OAuth callback" do
+      # Test that it authenticates
+      request.env['warden'] = mock("stub warden", :authenticate! => true, authenticated?: true, user: GDS::SSO::ApiUser.new)
+
+      @user_to_update.expects(:update_attributes).with({ 
+          "uid" => "a1s2d3",
+          "name" => "Joshua Marshall", 
+          "email" => "user@domain.com", 
+          "permissions" => { "GDS_SSO integration test" => ["signin", "new permission"] }}, as: :oauth)
+
+      User.expects(:find_by_uid).with("a1s2d3").returns(@user_to_update)
+
+      request.env['RAW_POST_DATA'] = user_update_json
+      put :update
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,4 +19,8 @@ require 'capybara/mechanize'
 
 include Warden::Test::Helpers
 
+RSpec.configure do |config|
+  config.mock_framework = :mocha
+end
+
 Dir[File.join(File.dirname(__FILE__), "support/**/*.rb")].each {|f| require f}


### PR DESCRIPTION
This is needed to support immediately updating permissions in apps from signonotron: https://www.pivotaltracker.com/story/show/31474431

This will be built on to implement immediately logging out suspended users.
