### PR TITLE
Check whether user is remotely signed out when asking user_signed_in?

### DIFF
--- a/lib/gds-sso/controller_methods.rb
+++ b/lib/gds-sso/controller_methods.rb
@@ -40,7 +40,7 @@ module GDS
       end
 
       def user_signed_in?
-        warden.authenticated?
+        warden.authenticated? && ! current_user.remotely_signed_out?
       end
 
       def current_user


### PR DESCRIPTION
In theory we wouldn't spot users were remotely signed out till we tried to re-authenticate them. This works deals with that by ensuring that any time we check sign in status we also check remote suspension status.
