### PR TITLE
make dependency on omniauth-gds less restrictive

### DIFF
--- a/gds-sso.gemspec
+++ b/gds-sso.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'rails', '>= 3.0.0'
   s.add_dependency 'warden', '~> 1.2'
-  s.add_dependency 'omniauth-gds', '0.0.3'
+  s.add_dependency 'omniauth-gds', '~> 0.0.3'
   s.add_dependency 'rack-accept', '~> 0.4.4'
 
   s.add_development_dependency 'rake',  '0.9.2.2'


### PR DESCRIPTION
I'd like to make a minor change to omniauth-gds (publish it to rubygems
instead of gemfury) and because of the exact dependency that gds-sso has
on omniauth-gds, this means that I have to release a new version of
gds-sso to pick up this change.

Using a ~> dependency would be a bit more lenient in future.
