### PR TITLE
Fix the end-to-end Signonotron integration tests

### DIFF
--- a/gds-sso.gemspec
+++ b/gds-sso.gemspec
@@ -35,10 +35,10 @@ Gem::Specification.new do |s|
   s.add_dependency 'rack-accept', '~> 0.4.4'
 
   s.add_development_dependency 'rake',  '0.9.2.2'
-  s.add_development_dependency 'mocha', '0.9.12'
+  s.add_development_dependency 'mocha', '0.13.3'
   s.add_development_dependency 'capybara', '1.1.2'
   s.add_development_dependency 'selenium-webdriver', '2.29.0' # Added to resolve dependency resolution fail
-  s.add_development_dependency 'rspec-rails', '2.9.0'
+  s.add_development_dependency 'rspec-rails', '2.12.2'
   s.add_development_dependency 'capybara-mechanize', '0.3.0'
   s.add_development_dependency 'combustion', '0.3.2'
   s.add_development_dependency 'gem_publisher', '1.0.0'

--- a/spec/requests/end_to_end_spec.rb
+++ b/spec/requests/end_to_end_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'timecop'
 
 describe "Integration of client using GDS-SSO with signonotron" do
   include Signonotron2IntegrationHelpers

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,9 +5,10 @@ require 'bundler'
 # Bad things happen if we don't ;-)
 ENV['GDS_SSO_STRATEGY'] = 'real'
 
-Bundler.require :default, :development
+Bundler.require :default
 
 require 'capybara/rspec'
+require 'combustion'
 
 Combustion.initialize!
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,6 +3,6 @@ require 'test/unit'
 
 Bundler.require :default, :development, :test
 
-require 'mocha'
+require 'mocha/setup'
 
 require 'gds-sso'


### PR DESCRIPTION
- Bump `mocha` and `rspec-rails` to mutually compatible versions which work with newer versions of Rails.
- Update test helper `require` to remove deprecation warning.
- Remove the `Bundler.require` for development dependencies, as it was trying to require `mocha` directly, which is now deprecated.
- Add in explicit requirements for development dependencies.
