### PR TITLE
Handle the user not existing in the database

### DIFF
--- a/app/controllers/api/user_controller.rb
+++ b/app/controllers/api/user_controller.rb
@@ -11,7 +11,7 @@ class Api::UserController < ApplicationController
 
   def reauth
     user = GDS::SSO::Config.user_klass.find_by_uid(params[:uid])
-    if user.set_remotely_signed_out!
+    if user.nil? || user.set_remotely_signed_out!
       head :ok
     else
       head 500

--- a/spec/controller/api_user_controller_spec.rb
+++ b/spec/controller/api_user_controller_spec.rb
@@ -69,6 +69,17 @@ describe Api::UserController, type: :controller do
       assert_equal 403, response.status
     end
 
+    it "should return success if user record doesn't exist" do
+      request.env['warden'] = mock("mock warden")
+      request.env['warden'].expects(:authenticate!).at_least_once.returns(true)
+      request.env['warden'].expects(:authenticated?).at_least_once.returns(true)
+      request.env['warden'].expects(:user).at_least_once.returns(GDS::SSO::ApiUser.new)
+
+      post :reauth, uid: "nonexistent-user"
+
+      assert_equal 200, response.status
+    end
+
     it "should set remotely_signed_out to true on the user" do
       # Test that it authenticates
       request.env['warden'] = mock("mock warden")


### PR DESCRIPTION
It was invoking .set_remotely_signed_out! on nil in that situation. Thanks to @benilovj for doing the detective work.
