### PR TITLE
Update the routes to remove match

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
-  match '/auth/gds/callback',               to: 'authentications#callback', as: :gds_sign_in
-  match '/auth/gds/sign_out',               to: 'authentications#sign_out', as: :gds_sign_out
-  match '/auth/failure',                    to: 'authentications#failure',  as: :auth_failure
-  match '/auth/gds/api/users/:uid',         to: "api/user#update", via: "PUT"
-  match '/auth/gds/api/users/:uid/reauth',  to: "api/user#reauth", via: "POST"
+  get '/auth/gds/callback',               to: 'authentications#callback', as: :gds_sign_in
+  get '/auth/gds/sign_out',               to: 'authentications#sign_out', as: :gds_sign_out
+  get  '/auth/failure',                   to: 'authentications#failure',  as: :auth_failure
+  put  '/auth/gds/api/users/:uid',        to: "api/user#update"
+  post '/auth/gds/api/users/:uid/reauth', to: "api/user#reauth"
 end


### PR DESCRIPTION
Lets be explicit and use the verbs which each action supports as `match` is depreicated in rails 4 when not used with a `:via` parameter.
