### PR TITLE
Including GDS::SSO::ControllerMethods into auth controller

### DIFF
--- a/app/controllers/authentications_controller.rb
+++ b/app/controllers/authentications_controller.rb
@@ -1,4 +1,6 @@
 class AuthenticationsController < ApplicationController
+  include GDS::SSO::ControllerMethods
+
   before_filter :authenticate_user!, :only => :callback
   skip_before_filter :require_signin_permission!
   layout false


### PR DESCRIPTION
We had an odd issue where we only included GDS::SSO::ControllerMethods in our admin controller, however as AuthenticationsController inherits from ApplicationController it needs to be included here instead, so that authenticate_user! is defined.

Alternatively the readme should be updated to state that GDS::SSO::ControllerMethods has to be included in the
ApplicationController
