### PR TITLE
Skip verify_authenticity_token in API controller

### DIFF
--- a/app/controllers/api/user_controller.rb
+++ b/app/controllers/api/user_controller.rb
@@ -24,13 +24,13 @@ class Api::UserController < ApplicationController
     # By doing this, we can reuse the code for creating/updating the user
     def build_gds_oauth_hash(user_json)
       OmniAuth::AuthHash.new(
-          uid: user_json['uid'], 
-          provider: 'gds', 
-          info: { 
-            name: user_json['name'], 
+          uid: user_json['uid'],
+          provider: 'gds',
+          info: {
+            name: user_json['name'],
             email: user_json['email']
-          }, 
-          extra: { 
+          },
+          extra: {
             user: { permissions: user_json['permissions'] }
           })
     end


### PR DESCRIPTION
I'm seeing ActionController::InvalidAuthenticityToken when the API tries to sync the permissions. So skip the checking.

skip_before_filter is both Rails 3 and 4 compatible.
