### PR TITLE
Users are now only ever a member of 0 or 1 orgs

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,8 @@
-# 5.0.0
+# 6.0.0 (Unreleased)
+
+* Changed "organisations" (array) to "organisation" (string)
+
+# 5.0.0 (Not recommended, see version 6.0.0)
 
 * Apps using gds-sso must now include a field in their User model for
   "organisations", which is an array of organisation slugs sourced from

--- a/README.md
+++ b/README.md
@@ -38,16 +38,15 @@ It should have the following fields:
     string   "name"
     string   "email"
     string   "uid"
+    string   "organisation"
     array    "permissions"
-    array    "organisations"
     boolean  "remotely_signed_out", :default => false
 
 You also need to include `GDS::SSO::ControllerMethods` in your ApplicationController
 
-For ActiveRecord, you probably want to declare permissions and organisations as "serialized" like this:
+For ActiveRecord, you probably want to declare permissions as "serialized" like this:
 
     serialize :permissions, Array
-    serialize :organisations, Array
 
 
 ## Use in development mode

--- a/app/controllers/api/user_controller.rb
+++ b/app/controllers/api/user_controller.rb
@@ -33,7 +33,7 @@ class Api::UserController < ApplicationController
           extra: {
             user: {
               permissions: user_json['permissions'],
-              organisations: user_json['organisations'],
+              organisation: user_json['organisation'],
             }
           })
     end

--- a/gds-sso.gemspec
+++ b/gds-sso.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'rails', '>= 3.0.0'
   s.add_dependency 'warden', '~> 1.2'
-  s.add_dependency 'omniauth-gds', '>= 1.0.0'
+  s.add_dependency 'omniauth-gds', '>= 2.0.0'
   s.add_dependency 'rack-accept', '~> 0.4.4'
 
   s.add_development_dependency 'rake',  '0.9.2.2'

--- a/lib/gds-sso/user.rb
+++ b/lib/gds-sso/user.rb
@@ -4,7 +4,7 @@ module GDS
   module SSO
     module User
       def included(base)
-        attr_accessible :uid, :email, :name, :permissions, :organisations, as: :oauth
+        attr_accessible :uid, :email, :name, :permissions, :organisation, as: :oauth
       end
 
       def has_permission?(permission)
@@ -19,7 +19,7 @@ module GDS
           'email'         => auth_hash['info']['email'],
           'name'          => auth_hash['info']['name'],
           'permissions'   => auth_hash['extra']['user']['permissions'],
-          'organisations' => auth_hash['extra']['user']['organisations'],
+          'organisation'  => auth_hash['extra']['user']['organisation'],
         }
       end
 

--- a/lib/gds-sso/warden_config.rb
+++ b/lib/gds-sso/warden_config.rb
@@ -110,7 +110,7 @@ Warden::Strategies.add(:gds_bearer_token) do
       'extra' => {
         'user' => {
           'permissions' => input['permissions'],
-          'organisations' => input['organisations'],
+          'organisation' => input['organisation'],
         }
       }
     }

--- a/spec/controller/api_user_controller_spec.rb
+++ b/spec/controller/api_user_controller_spec.rb
@@ -7,7 +7,7 @@ def user_update_json
       "name" => "Joshua Marshall",
       "email" => "user@domain.com",
       "permissions" => ["signin", "new permission"],
-      "organisations" => ["justice-league"]
+      "organisation" => "justice-league"
     }
   }.to_json
 end
@@ -60,8 +60,8 @@ describe Api::UserController, type: :controller do
       assert_equal "user@domain.com", @user_to_update.email
       expected_permissions = ["signin", "new permission"]
       assert_equal expected_permissions, @user_to_update.permissions
-      expected_organisations = ["justice-league"]
-      assert_equal expected_organisations, @user_to_update.organisations
+      expected_organisation = "justice-league"
+      assert_equal expected_organisation, @user_to_update.organisation
     end
   end
 

--- a/spec/internal/app/models/user.rb
+++ b/spec/internal/app/models/user.rb
@@ -2,7 +2,6 @@ class User < ActiveRecord::Base
   include GDS::SSO::User
 
   serialize :permissions, Array
-  serialize :organisations, Array
 
-  attr_accessible :uid, :email, :name, :permissions, :organisations, as: :oauth
+  attr_accessible :uid, :email, :name, :permissions, :organisation, as: :oauth
 end

--- a/spec/internal/db/schema.rb
+++ b/spec/internal/db/schema.rb
@@ -5,6 +5,6 @@ ActiveRecord::Schema.define do
     t.string "email",       :null => false
     t.boolean "remotely_signed_out"
     t.text   "permissions"
-    t.text   "organisations"
+    t.string "organisation"
   end
 end

--- a/test/user_test.rb
+++ b/test/user_test.rb
@@ -8,12 +8,12 @@ class TestUser < Test::Unit::TestCase
       'uid' => 'abcde',
       'credentials' => {'token' => 'abcdefg', 'secret' => 'abcdefg'},
       'info' => {'name' => 'Matt Patterson', 'email' => 'matt@alphagov.co.uk'},
-      'extra' => {'user' => {'permissions' => [], 'organisations' => []}}
+      'extra' => {'user' => {'permissions' => [], 'organisation' => nil}}
     }
   end
 
   def test_user_params_creation
-    expected = {'uid' => 'abcde', 'name' => 'Matt Patterson', 'email' => 'matt@alphagov.co.uk', "permissions" => [], "organisations" => []}
+    expected = {'uid' => 'abcde', 'name' => 'Matt Patterson', 'email' => 'matt@alphagov.co.uk', "permissions" => [], "organisation" => nil}
     assert_equal expected, GDS::SSO::User.user_params_from_auth_hash(@auth_hash)
   end
 end


### PR DESCRIPTION
This means simpler code in Signon and apps using organisation membership, and simplifies Signon conceptually.

Nothing is using "organisations" yet, so the breaking change shouldn't be a problem.

I did wonder about yanking the version with "organisations", but it's probably a bad idea.
