### PR TITLE
attr_accessible only called if defined in GDS::SSO::User

### DIFF
--- a/lib/gds-sso/user.rb
+++ b/lib/gds-sso/user.rb
@@ -6,7 +6,7 @@ module GDS
       extend ActiveSupport::Concern
 
       included do
-        if respond_to?(:attr_accessible) && !(Gem::Version.new(Rails.version) >= Gem::Version.new("4.0"))
+        if (Gem::Version.new(Rails.version) < Gem::Version.new("4.0")) && respond_to?(:attr_accessible)
           attr_accessible :uid, :email, :name, :permissions, :organisation_slug, as: :oauth
         end
       end


### PR DESCRIPTION
attr_accessible and attr_protected have been removed in Rails 4
favoring using strong parameters instead. This change prevents large
and unhelpful explosions when a rails 4 model includes GDS::SSO::User.
