### PR TITLE
Let's actually verify SSL certs when talking to signon.

### DIFF
--- a/lib/gds-sso.rb
+++ b/lib/gds-sso.rb
@@ -29,7 +29,6 @@ module GDS
             site: GDS::SSO::Config.oauth_root_url,
             authorize_url: "#{GDS::SSO::Config.oauth_root_url}/oauth/authorize",
             token_url: "#{GDS::SSO::Config.oauth_root_url}/oauth/access_token",
-            ssl: { verify: false }
           }
       end
 


### PR DESCRIPTION
This reverts the change made in 9262d94221a46ad9329a5a4040cb71cbe5fdc1f7 back when we didn't have valid SSL certs in preview.

This is not a major security issue because this only applies to requests between a client application and the authorization server.  These requests are internal to our data centre, and don't cross an untrusted network.  Were that not the case, this would be more of an issue.
