### PR TITLE
Remove references to slimmer.

### DIFF
--- a/lib/gds-sso/controller_methods.rb
+++ b/lib/gds-sso/controller_methods.rb
@@ -26,7 +26,6 @@ module GDS
       def require_signin_permission!
         authorise_user!('signin')
       rescue PermissionDeniedException
-        skip_slimmer
         render "authorisations/cant_signin", layout: "unauthorised", status: :forbidden
       end
 
@@ -52,11 +51,6 @@ module GDS
 
       def warden
         request.env['warden']
-      end
-
-      def skip_slimmer
-        # If slimmer used, without this you would see a generic 400 error page
-        headers["X-Slimmer-Skip"] = "1"
       end
     end
   end


### PR DESCRIPTION
None of the admin apps run through slimmer any more so there's no need
to skip slimmer.
