### PR TITLE
Correcting mock api strategy used on dev

### DIFF
--- a/lib/gds-sso/warden_config.rb
+++ b/lib/gds-sso/warden_config.rb
@@ -171,12 +171,13 @@ Warden::Strategies.add(:mock_gds_sso_api_access) do
     logger.debug("Authenticating with mock_gds_sso_api_access strategy")
     dummy_api_user = GDS::SSO.test_user || GDS::SSO::Config.user_klass.where(email: "dummyapiuser@domain.com").first
     if dummy_api_user.nil?
-      dummy_api_user = GDS::SSO::Config.user_klass.create!(
+      dummy_api_user = GDS::SSO::Config.user_klass.new(
           email: "dummyapiuser@domain.com",
           uid: "#{rand(10000)}",
           name: "Dummy API user created by gds-sso",
-          permissions: ["signin"],
           as: :oauth)
+      dummy_api_user.permissions = ["signin"]
+      dummy_api_user.save!
     end
     success!(dummy_api_user)
   end


### PR DESCRIPTION
Permissions can't be mass-assigned

/cc @benilovj, @bishboria
