### PR TITLE
Support Rails 4.1 JSON encoding of sessions.

### DIFF
--- a/spec/unit/session_serialisation_spec.rb
+++ b/spec/unit/session_serialisation_spec.rb
@@ -18,12 +18,12 @@ describe Warden::SessionSerializer do
   end
 
   describe "serializing a user" do
-
-    it "should return the uid and a timestamp" do
+    it "should return the uid and an ISO 8601 string timestamp" do
       Timecop.freeze
       result = @serializer.serialize(@user)
 
-      expect(result).to eq([1234, Time.now.utc])
+      expect(result).to eq([1234, Time.now.utc.iso8601])
+      expect(result.last).to be_a(String)
     end
 
     it "should return nil if the user has no uid" do
@@ -35,10 +35,18 @@ describe Warden::SessionSerializer do
   end
 
   describe "deserialize a user" do
-    it "should return the user if the timestamp is current" do
+    it "should return the user if the timestamp is current and a Time" do
       expect(User).to receive(:where).with(:uid => 1234, :remotely_signed_out => false).and_return(double(:first => :a_user))
 
       result = @serializer.deserialize [1234, Time.now.utc - GDS::SSO::Config.auth_valid_for + 3600]
+
+      expect(result).to equal(:a_user)
+    end
+
+    it "should return the user if the timestamp is current and is an ISO 8601 string" do
+      expect(User).to receive(:where).with(:uid => 1234, :remotely_signed_out => false).and_return(double(:first => :a_user))
+
+      result = @serializer.deserialize [1234, (Time.now.utc - GDS::SSO::Config.auth_valid_for + 3600).iso8601]
 
       expect(result).to equal(:a_user)
     end
@@ -55,6 +63,14 @@ describe Warden::SessionSerializer do
       expect(User).not_to receive(:where)
 
       result = @serializer.deserialize 1234
+
+      expect(result).to be_nil
+    end
+
+    it "should return nil for a user with a badly formatted timestamp" do
+      expect(User).not_to receive(:where)
+
+      result = @serializer.deserialize [1234, 'this is not a timestamp']
 
       expect(result).to be_nil
     end


### PR DESCRIPTION
Continues to support marshalled sessions.
