### PR TITLE
Set appropriate content type on responses

### DIFF
--- a/app/controllers/api/user_controller.rb
+++ b/app/controllers/api/user_controller.rb
@@ -9,15 +9,15 @@ class Api::UserController < ActionController::Base
     user_json = JSON.parse(request.body.read)['user']
     oauth_hash = build_gds_oauth_hash(user_json)
     GDS::SSO::Config.user_klass.find_for_gds_oauth(oauth_hash)
-    head :ok
+    head :ok, content_type: 'text/plain'
   end
 
   def reauth
     user = GDS::SSO::Config.user_klass.where(:uid => params[:uid]).first
     if user.nil? || user.set_remotely_signed_out!
-      head :ok
+      head :ok, content_type: 'text/plain'
     else
-      head 500
+      head 500, content_type: 'text/plain'
     end
   end
 

--- a/spec/controller/api_user_controller_spec.rb
+++ b/spec/controller/api_user_controller_spec.rb
@@ -60,6 +60,7 @@ describe Api::UserController, type: :controller do
       expect(@user_to_update.email).to eq("user@domain.com")
       expect(@user_to_update.permissions).to eq(["signin", "new permission"])
       expect(@user_to_update.organisation_slug).to eq("justice-league")
+      expect(response.content_type).to eq('text/plain')
     end
   end
 
@@ -86,6 +87,7 @@ describe Api::UserController, type: :controller do
       post :reauth, uid: "nonexistent-user"
 
       expect(response.status).to eq(200)
+      expect(response.content_type).to eq('text/plain')
     end
 
     it "should set remotely_signed_out to true on the user" do
@@ -99,6 +101,7 @@ describe Api::UserController, type: :controller do
 
       @user_to_update.reload
       expect(@user_to_update.remotely_signed_out).to be_true
+      expect(response.content_type).to eq('text/plain')
     end
   end
 end


### PR DESCRIPTION
By default our responses are setting the content-type to "text/html", which confuses slimmer on whitehall into trying to process the response body. We should be explicit about the content-type of the response so it doesn't incorrectly default to "text/html".
