### PR TITLE
Fix warnings about invalid gemspec.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,10 @@ source "https://rubygems.org"
 
 # Specify your gem's dependencies in gds-sso.gemspec
 gemspec
+
+# The test suite currently assumes a Rails 3.2 client.
+# TODO: Investigate a matrix build against multiple Rails versions.
+gem 'rails', '~> 3.2.19'
+
+## Gems added to resolve dependency resolution
+gem 'mechanize', '2.6.0'

--- a/gds-sso.gemspec
+++ b/gds-sso.gemspec
@@ -48,10 +48,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'sqlite3', '1.3.6'
   s.add_development_dependency 'timecop', '0.3.5'
 
-  # The test suite currently assumes a Rails 3.2 client.
-  # TODO: Investigate a matrix build against multiple Rails versions.
-  s.add_development_dependency 'rails', '~> 3.2.19'
-
-  ## Gems added to resolve dependency resolution
-  s.add_development_dependency 'mechanize', '2.6.0'
+  # Additional development dependencies added to Gemfile to aid dependency resolution.
 end


### PR DESCRIPTION
Move the gems added to resolve dependency resolution out of the gemspec
and into the Gemfile.  This prevents warnings being generated by newer
versions of bundler because rails was listed twice in the gemspec.
