### PR TITLE
Version bump to 9.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 9.3.0
+
+* Include oauth client_id when requesting user details from signon.
+  This allows signon to verify that the token used belongs to the app making
+  the request.  Sending this id will become mandatory in future.
+
 # 9.2.7
 
 * update/reauth requests get a content-type of 'text/plain' in responses

--- a/lib/gds-sso/version.rb
+++ b/lib/gds-sso/version.rb
@@ -1,5 +1,5 @@
 module GDS
   module SSO
-    VERSION = "9.2.7"
+    VERSION = "9.3.0"
   end
 end


### PR DESCRIPTION
Note: also renamed `CHANGELOG` to `CHANGELOG.md` so that github picks up that it's markdown and formats it nicely.
