### PR TITLE
Ensure bundle install is run for all rubies

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -10,7 +10,8 @@ rm -f gemfiles/*.gemfile.lock
 # Exclude /tmp from git clean as it only contains the signonotron checkout
 git clean -fdxe /tmp
 
-bundle install --path "${HOME}/bundles/${JOB_NAME}"
+RBENV_VERSION=1.9.3 bundle install --path "${HOME}/bundles/${JOB_NAME}"
+RBENV_VERSION=2.1 bundle install --path "${HOME}/bundles/${JOB_NAME}"
 
 RBENV_VERSION=1.9.3 bundle exec rake
 RBENV_VERSION=2.1 bundle exec rake


### PR DESCRIPTION
`bundle install` needs to be run explicitly for each version of Ruby the test suite is being run against to make sure the base set of gems are present. This should fix the currently broken build.
