### PR TITLE
Add specs for the User class interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Create a `config/initializers/gds-sso.rb` that looks like:
       config.oauth_root_url = "http://localhost:3001"
     end
 
-The user model must include the GDS::SSO::User module.
+The user model must include the `GDS::SSO::User` module.
 
 It should have the following fields:
 
@@ -43,12 +43,21 @@ It should have the following fields:
     array    "permissions"
     boolean  "remotely_signed_out", :default => false
 
-You also need to include `GDS::SSO::ControllerMethods` in your ApplicationController
+You also need to include `GDS::SSO::ControllerMethods` in your ApplicationController.
 
 For ActiveRecord, you probably want to declare permissions as "serialized" like this:
 
     serialize :permissions, Array
 
+If your app is using `rspec`, there is a [shared examples spec](/lib/gds-sso/lint/user_spec.rb) that can be used to verify that your `User` model implements the necessary methods for `gds-sso` to work correctly. To use it:
+
+```ruby
+require 'gds-sso/lint/user_spec'
+
+describe User do
+  it_behaves_like "a gds-sso user class"
+end
+```
 
 ## Use in development mode
 
@@ -62,5 +71,4 @@ To make it use a real strategy (e.g. if you're testing an app against the signon
 
 Once that's done, set an environment variable when you run your app. e.g.:
 
-    GDS_SSO_STRATEGY=real bundle exec rails s 
-
+    GDS_SSO_STRATEGY=real bundle exec rails s

--- a/lib/gds-sso/lint/user_spec.rb
+++ b/lib/gds-sso/lint/user_spec.rb
@@ -1,0 +1,52 @@
+RSpec.shared_examples "a gds-sso user class" do
+  subject { described_class.new }
+
+  it "implements #where" do
+    expect(described_class).to respond_to(:where)
+
+    result = described_class.where(uid: '123')
+    expect(result).to respond_to(:first)
+  end
+
+  it "implements #update_attribute" do
+    expect(subject).to respond_to(:update_attribute)
+
+    subject.update_attribute(:remotely_signed_out, true)
+    expect(subject).to be_remotely_signed_out
+  end
+
+  it "implements #update_attributes" do
+    expect(subject).to respond_to(:update_attributes)
+  end
+
+  it "implements #create!" do
+    expect(described_class).to respond_to(:create!)
+  end
+
+  it "implements #remotely_signed_out?" do
+    expect(subject).to respond_to(:remotely_signed_out?)
+  end
+
+  specify "the User class and GDS::SSO::User mixin work together" do
+    auth_hash = {
+      'uid' => '12345',
+      'info' => {
+        'name' => 'Joe Smith',
+        'email' => 'joe.smith@example.com',
+      },
+      'extra' => {
+        'user' => {
+          'permissions' => ['signin'],
+          'organisation_slug' => 'cabinet-office',
+        }
+      }
+    }
+
+    user = described_class.find_for_gds_oauth(auth_hash)
+    expect(user).to be_an_instance_of(described_class)
+    expect(user.name).to eq("Joe Smith")
+    expect(user.email).to eq('joe.smith@example.com')
+    expect(user.permissions).to eq(['signin'])
+    expect(user.organisation_slug).to eq('cabinet-office')
+  end
+end


### PR DESCRIPTION
When an app integrates `gds-sso`, it needs to have a `User` class
that includes the `GDS::SSO::User` module and fulfils a certain contract.

This change adds a RSpec shared spec that can be included in the app's `User`
specs:

``` ruby

require 'gds-sso/lint/user_spec'

describe User do
  it_behaves_like "a user class"
end
```

The motivation for this comes from introducing bugs by bumping `gds-sso` and breaking SSO integration on preview.
