### PR TITLE
GDS::SSO::User has a disabled field

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ It should have the following fields:
     string   "organisation_slug"
     array    "permissions"
     boolean  "remotely_signed_out", :default => false
+    boolean  "disabled", :default => false
 
 You also need to include `GDS::SSO::ControllerMethods` in your ApplicationController.
 

--- a/app/controllers/api/user_controller.rb
+++ b/app/controllers/api/user_controller.rb
@@ -36,6 +36,7 @@ class Api::UserController < ActionController::Base
             user: {
               permissions: user_json['permissions'],
               organisation_slug: user_json['organisation_slug'],
+              disabled: user_json['disabled'],
             }
           })
     end

--- a/lib/gds-sso/user.rb
+++ b/lib/gds-sso/user.rb
@@ -11,7 +11,7 @@ module GDS
 
       included do
         if GDS::SSO::User.below_rails_4? && respond_to?(:attr_accessible)
-          attr_accessible :uid, :email, :name, :permissions, :organisation_slug, as: :oauth
+          attr_accessible :uid, :email, :name, :permissions, :organisation_slug, :disabled, as: :oauth
         end
       end
 
@@ -23,11 +23,12 @@ module GDS
 
       def self.user_params_from_auth_hash(auth_hash)
         {
-          'uid'           => auth_hash['uid'],
-          'email'         => auth_hash['info']['email'],
-          'name'          => auth_hash['info']['name'],
-          'permissions'   => auth_hash['extra']['user']['permissions'],
-          'organisation_slug'  => auth_hash['extra']['user']['organisation_slug'],
+          'uid' => auth_hash['uid'],
+          'email' => auth_hash['info']['email'],
+          'name' => auth_hash['info']['name'],
+          'permissions' => auth_hash['extra']['user']['permissions'],
+          'organisation_slug' => auth_hash['extra']['user']['organisation_slug'],
+          'disabled' => auth_hash['extra']['user']['disabled'],
         }
       end
 

--- a/spec/controller/api_user_controller_spec.rb
+++ b/spec/controller/api_user_controller_spec.rb
@@ -7,7 +7,8 @@ def user_update_json
       "name" => "Joshua Marshall",
       "email" => "user@domain.com",
       "permissions" => ["signin", "new permission"],
-      "organisation_slug" => "justice-league"
+      "organisation_slug" => "justice-league",
+      "disabled" => false,
     }
   }.to_json
 end

--- a/spec/internal/db/schema.rb
+++ b/spec/internal/db/schema.rb
@@ -6,5 +6,6 @@ ActiveRecord::Schema.define do
     t.boolean "remotely_signed_out"
     t.text   "permissions"
     t.string "organisation_slug"
+    t.boolean "disabled",  :default => false
   end
 end

--- a/spec/requests/end_to_end_spec.rb
+++ b/spec/requests/end_to_end_spec.rb
@@ -9,6 +9,8 @@ describe "Integration of client using GDS-SSO with signonotron" do
   end
 
   before :each do
+    # points to an internal app, using combustion gem
+    # see spec/internal
     @client_host = 'www.example-client.com'
     Capybara.current_driver = :mechanize
     Capybara::Mechanize.local_hosts << @client_host

--- a/spec/unit/user_spec.rb
+++ b/spec/unit/user_spec.rb
@@ -11,12 +11,18 @@ describe GDS::SSO::User do
       'uid' => 'abcde',
       'credentials' => {'token' => 'abcdefg', 'secret' => 'abcdefg'},
       'info' => {'name' => 'Matt Patterson', 'email' => 'matt@alphagov.co.uk'},
-      'extra' => {'user' => {'permissions' => [], 'organisation_slug' => nil}}
+      'extra' => {'user' => {'permissions' => [], 'organisation_slug' => nil, 'disabled' => false}}
     }
   end
 
   it "should extract the user params from the oauth hash" do
-    expected = {'uid' => 'abcde', 'name' => 'Matt Patterson', 'email' => 'matt@alphagov.co.uk', "permissions" => [], "organisation_slug" => nil}
+    expected = {'uid' => 'abcde',
+      'name' => 'Matt Patterson',
+      'email' => 'matt@alphagov.co.uk',
+      "permissions" => [],
+      "organisation_slug" => nil,
+      'disabled' => false,
+    }
     expect(GDS::SSO::User.user_params_from_auth_hash(@auth_hash)).to eq(expected)
   end
 


### PR DESCRIPTION
www.agileplannerapp.com/boards/173808/cards/5886

This field represents a user's Signon state, so that apps can decide how to treat them differently. For example, Signon can set `disabled` to true for suspended users.
