### PR TITLE
Release 10.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 10.0.0
+
+* Add a `disabled` field to GDS::SSO::User to reflect Signon user state.
+  Breaking change: Requires consuming apps to add a `disabled` field to their user model
+
 # 9.4.0
 
 * Add an RSpec shared example for validating that the User model in the app

--- a/lib/gds-sso/version.rb
+++ b/lib/gds-sso/version.rb
@@ -1,5 +1,5 @@
 module GDS
   module SSO
-    VERSION = "9.4.0"
+    VERSION = "10.0.0"
   end
 end


### PR DESCRIPTION
www.agileplannerapp.com/boards/173808/cards/5886

Add a `disabled` field to GDS::SSO::User to reflect Signon user state
Breaking change: Requires consuming apps to add a `disabled` field to their user model
Releases: https://github.com/alphagov/gds-sso/pull/62
