### PR TITLE
Strengthen lint specs around User model contract

### DIFF
--- a/lib/gds-sso/lint/user_spec.rb
+++ b/lib/gds-sso/lint/user_spec.rb
@@ -16,7 +16,8 @@ RSpec.shared_examples "a gds-sso user class" do
   end
 
   it "implements #update_attributes" do
-    expect(subject).to respond_to(:update_attributes)
+    subject.update_attributes(email: "ab@c.com")
+    expect(subject.email).to eq("ab@c.com")
   end
 
   it "implements #create!" do


### PR DESCRIPTION
During an upgrade of the Support app to Rails 4, the gds-sso
integration broke because the User model in Support didn't support
`update_attributes` with one parameter (which is needed [here](https://github.com/alphagov/gds-sso/blob/v9.4.0/lib/gds-sso/user.rb#L52)).

This change changes the lint specs to exercise the `User#update_attributes` method more.

/cc @alext @issyl0 