### PR TITLE
Add organisation_content_id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Add support for organisation_content_id on the user model
+
 # 10.0.1
 
 * Fix the user model linter to work with a uid column defined as `NOT NULL`

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ It should have the following fields:
     string   "email"
     string   "uid"
     string   "organisation_slug"
+    string   "organisation_content_id"
     array    "permissions"
     boolean  "remotely_signed_out", :default => false
     boolean  "disabled", :default => false

--- a/app/controllers/api/user_controller.rb
+++ b/app/controllers/api/user_controller.rb
@@ -36,6 +36,7 @@ class Api::UserController < ActionController::Base
             user: {
               permissions: user_json['permissions'],
               organisation_slug: user_json['organisation_slug'],
+              organisation_content_id: user_json['organisation_content_id'],
               disabled: user_json['disabled'],
             }
           })

--- a/gds-sso.gemspec
+++ b/gds-sso.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'warden', '~> 1.2'
   s.add_dependency 'oauth2', '~> 1.0'
   s.add_dependency 'omniauth', '~> 1.2'
-  s.add_dependency 'omniauth-gds', '~> 3.1'
+  s.add_dependency 'omniauth-gds', '~> 3.2'
   s.add_dependency 'warden-oauth2', '~> 0.0.1'
   s.add_dependency 'rack-accept', '~> 0.4.4'
   s.add_dependency 'multi_json', '~> 1.0'

--- a/lib/gds-sso/bearer_token.rb
+++ b/lib/gds-sso/bearer_token.rb
@@ -38,6 +38,7 @@ module GDS
             'user' => {
               'permissions' => input['permissions'],
               'organisation_slug' => input['organisation_slug'],
+              'organisation_content_id' => input['organisation_content_id'],
             }
           }
         }

--- a/lib/gds-sso/lint/user_spec.rb
+++ b/lib/gds-sso/lint/user_spec.rb
@@ -39,6 +39,7 @@ RSpec.shared_examples "a gds-sso user class" do
         'user' => {
           'permissions' => ['signin'],
           'organisation_slug' => 'cabinet-office',
+          'organisation_content_id' => '91e57ad9-29a3-4f94-9ab4-5e9ae6d13588'
         }
       }
     }
@@ -50,5 +51,6 @@ RSpec.shared_examples "a gds-sso user class" do
     expect(user.email).to eq('joe.smith@example.com')
     expect(user.permissions).to eq(['signin'])
     expect(user.organisation_slug).to eq('cabinet-office')
+    expect(user.organisation_content_id).to eq('91e57ad9-29a3-4f94-9ab4-5e9ae6d13588')
   end
 end

--- a/lib/gds-sso/user.rb
+++ b/lib/gds-sso/user.rb
@@ -11,7 +11,7 @@ module GDS
 
       included do
         if GDS::SSO::User.below_rails_4? && respond_to?(:attr_accessible)
-          attr_accessible :uid, :email, :name, :permissions, :organisation_slug, :disabled, as: :oauth
+          attr_accessible :uid, :email, :name, :permissions, :organisation_slug, :organisation_content_id, :disabled, as: :oauth
         end
       end
 
@@ -28,6 +28,7 @@ module GDS
           'name' => auth_hash['info']['name'],
           'permissions' => auth_hash['extra']['user']['permissions'],
           'organisation_slug' => auth_hash['extra']['user']['organisation_slug'],
+          'organisation_content_id' => auth_hash['extra']['user']['organisation_content_id'],
           'disabled' => auth_hash['extra']['user']['disabled'],
         }
       end

--- a/spec/controller/api_user_controller_spec.rb
+++ b/spec/controller/api_user_controller_spec.rb
@@ -8,6 +8,7 @@ def user_update_json
       "email" => "user@domain.com",
       "permissions" => ["signin", "new permission"],
       "organisation_slug" => "justice-league",
+      "organisation_content_id" => "aae1319e-5788-4677-998c-f1a53af528d0",
       "disabled" => false,
     }
   }.to_json
@@ -67,6 +68,7 @@ describe Api::UserController, type: :controller do
       expect(@user_to_update.email).to eq("user@domain.com")
       expect(@user_to_update.permissions).to eq(["signin", "new permission"])
       expect(@user_to_update.organisation_slug).to eq("justice-league")
+      expect(@user_to_update.organisation_content_id).to eq("aae1319e-5788-4677-998c-f1a53af528d0")
       expect(response.content_type).to eq('text/plain')
     end
   end

--- a/spec/internal/db/schema.rb
+++ b/spec/internal/db/schema.rb
@@ -6,6 +6,7 @@ ActiveRecord::Schema.define do
     t.boolean "remotely_signed_out"
     t.text   "permissions"
     t.string "organisation_slug"
+    t.string "organisation_content_id"
     t.boolean "disabled",  :default => false
   end
 end

--- a/spec/unit/user_spec.rb
+++ b/spec/unit/user_spec.rb
@@ -11,7 +11,11 @@ describe GDS::SSO::User do
       'uid' => 'abcde',
       'credentials' => {'token' => 'abcdefg', 'secret' => 'abcdefg'},
       'info' => {'name' => 'Matt Patterson', 'email' => 'matt@alphagov.co.uk'},
-      'extra' => {'user' => {'permissions' => [], 'organisation_slug' => nil, 'disabled' => false}}
+      'extra' => {
+        'user' => {
+          'permissions' => [], 'organisation_slug' => nil, "organisation_content_id" => nil, 'disabled' => false
+        }
+      }
     }
   end
 
@@ -21,6 +25,7 @@ describe GDS::SSO::User do
       'email' => 'matt@alphagov.co.uk',
       "permissions" => [],
       "organisation_slug" => nil,
+      "organisation_content_id" => nil,
       'disabled' => false,
     }
     expect(GDS::SSO::User.user_params_from_auth_hash(@auth_hash)).to eq(expected)


### PR DESCRIPTION
We want to move away from organisation_slug as these change whereas content_ids
are stable. Successfully tested in development.

~~Depends on (and will need to rebased to upgrade to): https://github.com/alphagov/omniauth-gds/pull/7~~