### PR TITLE
Try using the original path to give a clean path

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -1,5 +1,8 @@
 #!/bin/bash -xe
 
+# Capture the clean path so that we can use it to execute signon isolated from gds-sso
+export ORIGINAL_PATH=$PATH
+
 # Make sure this runs, even if something blows up.
 trap "bundle exec rake signonotron:stop" EXIT
 

--- a/spec/tasks/signonotron_tasks.rake
+++ b/spec/tasks/signonotron_tasks.rake
@@ -30,6 +30,9 @@ namespace :signonotron do
         "/usr/bin/env " + env_to_clear.map { |e| "-u #{e}" }.join(" ")
       end
       env_stuff += " RAILS_ENV=test"
+      if ENV.has_key?('ORIGINAL_PATH')
+        env_stuff += " PATH=#{ENV.fetch('ORIGINAL_PATH')}"
+      end
 
       puts "Running bundler"
       puts `#{env_stuff} bundle install --path=#{gem_root + 'tmp' + "#{@app_to_launch}_bundle"}`


### PR DESCRIPTION
On CI, the PATH is having Ruby executables added to it when Ruby is used for
the first time. This means that Signon is run with the Ruby version (eg 1.9.3)
being used to test gds-sso, rather than the Signon's Ruby version (2.1.4).

This causes a failure because the byebug gem, which requires Ruby 2+, has recently been added to  Signon's bundle, and so won't install under 1.9.3.

The build is still failing because there are further problems relating to database index names which @bishboria and I are trying to fix.

Props to @alext for his help.