### PR TITLE
Use MySQL for running Signon

### DIFF
--- a/spec/fixtures/integration/signonotron2_database.yml
+++ b/spec/fixtures/integration/signonotron2_database.yml
@@ -1,5 +1,0 @@
-test: &test
-   adapter: sqlite3
-   database: db/test.sqlite3
-   pool: 5
-   timeout: 5000

--- a/spec/support/signonotron2_integration_helpers.rb
+++ b/spec/support/signonotron2_integration_helpers.rb
@@ -34,13 +34,19 @@ module Signonotron2IntegrationHelpers
     load_signonotron_fixture("authorize_api_users.sql")
   end
 
-  def load_signonotron_fixture(fixture_sql_file)
-    fixtures_path = Pathname.new(File.join(File.dirname(__FILE__), '../fixtures/integration'))
-    app = "signonotron2"
-    path_to_app = Rails.root.join('..','..','tmp',app)
+  def load_signonotron_fixture(filename)
+    db = YAML.load_file(signon_path + "/config/database.yml")['test']
 
-    db = YAML.load_file(fixtures_path + "#{app}_database.yml")['test']
-    cmd = "sqlite3 #{path_to_app + db['database']} < #{fixtures_path + "#{fixture_sql_file}"}"
+    cmd = "mysql #{db['database']} -u#{db['username']} -p#{db['password']} < #{fixture_file(filename)}"
     system cmd or raise "Error loading signonotron fixture"
+  end
+
+private
+  def fixture_file(filename)
+    File.join(File.dirname(__FILE__), '../fixtures/integration', filename)
+  end
+
+  def signon_path
+    Rails.root.join('..','..','tmp','signonotron2').to_s
   end
 end

--- a/spec/tasks/signonotron_tasks.rake
+++ b/spec/tasks/signonotron_tasks.rake
@@ -36,7 +36,6 @@ namespace :signonotron do
 
       puts "Running bundler"
       puts `#{env_stuff} bundle install --path=#{gem_root + 'tmp' + "#{@app_to_launch}_bundle"}`
-      FileUtils.cp gem_root.join('spec', 'fixtures', 'integration', "#{@app_to_launch}_database.yml"), File.join('config', 'database.yml')
       puts `#{env_stuff} bundle exec rake db:drop db:create db:schema:load`
 
       puts "Starting signonotron instance in the background"


### PR DESCRIPTION
This fixes an error we are seeing when running the integration tests since
upgrading Signon to Rails 4.0.x:
```
  ArgumentError: Index name 'index_batch_invite_app_perms_on_batch_invite_and_supported_perm' on table 'batch_invitation_application_permissions' is too long; the limit is 62 characters
```
Signon's index names are limited to 64 characters as this is the limit for
MySQL (in Rails). For sqlite, Rails' limit is 62 characters. See:
https://github.com/rails/rails/blob/v4.0.13/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb#L193-L198

Signon is developed and tested against MySQL, so let's stop expecting it to
work on sqlite.

The build is still failing because of a separate problem that also appeared when we upgraded Signon to Rails 4, relating to Doorkeeper.