### PR TITLE
Add `password_changed_at` to fixture data

### DIFF
--- a/spec/fixtures/integration/signonotron2.sql
+++ b/spec/fixtures/integration/signonotron2.sql
@@ -17,8 +17,8 @@ INSERT INTO `supported_permissions` (id, application_id, name, created_at, updat
 INSERT INTO `supported_permissions` (id, application_id, name, created_at, updated_at)
               VALUES (2,2,'signin','2012-04-19 13:26:54','2012-04-19 13:26:54');
 
-INSERT INTO `users` (id, email, encrypted_password, password_salt, created_at, updated_at, confirmed_at, name, uid, role)
-              VALUES (1,'test@example-client.com','bb8e19edbaa1e7721abe0faa5c1663a7685950093b8c7eceb0f2e3889bdea4c5f17ca97820b2c663edf46ea532d1a9baa04b680fc537b4de8a3f376dd28e3ffd','MpLsZ8q1UaAojTa6bTC6','2012-04-19 13:26:54','2012-04-19 13:26:54','2012-04-19 13:26:54','Test User','integration-uid', "normal");
+INSERT INTO `users` (id, email, encrypted_password, password_salt, created_at, updated_at, confirmed_at, name, uid, role, password_changed_at)
+              VALUES (1,'test@example-client.com','bb8e19edbaa1e7721abe0faa5c1663a7685950093b8c7eceb0f2e3889bdea4c5f17ca97820b2c663edf46ea532d1a9baa04b680fc537b4de8a3f376dd28e3ffd','MpLsZ8q1UaAojTa6bTC6','2012-04-19 13:26:54','2012-04-19 13:26:54','2012-04-19 13:26:54','Test User','integration-uid', "normal", NOW());
 
 INSERT INTO `user_application_permissions` (user_id, application_id, supported_permission_id, created_at, updated_at)
               VALUES (1,1,1,'2012-04-19 13:26:54','2012-04-19 13:26:54');


### PR DESCRIPTION
With the updates to the password_expiry module in signonotron, it now
requires a password change if this field is `NULL`. In practice, this
field is set by ActiveRecord on creation, and in production data only
one user has `NULL`, which is an API user which is unaffected by
password expiry.

This fixes the integration tests that run against signonotron by
explicitly specifying that the user’s password is “fresh”.