### PR TITLE
Remove WWTD gem and explicitly define testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,0 @@
-script: 'bundle exec rake signonotron:start spec'
-gemfile:
-  - gemfiles/rails_3.2.gemfile
-  - gemfiles/rails_4.0.gemfile
-  - gemfiles/rails_4.1.gemfile

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,5 @@
 require 'bundler/setup'
 require 'bundler/gem_tasks'
-require 'wwtd/tasks'
 
 Bundler::GemHelper.install_tasks
 
@@ -25,4 +24,4 @@ task :publish_gem do |t|
   puts "Published #{gem}" if gem
 end
 
-task :default => [:wwtd]
+task :default => ["signonotron:start", "spec"]

--- a/gds-sso.gemspec
+++ b/gds-sso.gemspec
@@ -47,7 +47,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'gem_publisher', '1.0.0'
   s.add_development_dependency 'sqlite3', '1.3.9'
   s.add_development_dependency 'timecop', '0.3.5'
-  s.add_development_dependency 'wwtd'
 
   # Additional development dependencies added to Gemfile to aid dependency resolution.
 end


### PR DESCRIPTION
This repo made use of the "wwtd" gem (what would travis do) in order to
run a pseudo build matrix based on gemfile definitions in `travis.yml`.
The gem is fairly opaque and runs `bundle install` with `--quiet` by
default, with no way of overriding it. This was masking errors in CI
which, it turned out, were caused by the gem anyway.

This PR removes wwtd and unpacks its behaviour into a couple of bash
loops, making the behaviour more explicit and obvious. And fixes the
error.

The `signonotron:stop` task in the bash trap directive has been
replaced with a pure shell kill command, due to the uncertain nature of
the bundle environment at the time the trap is called.