### PR TITLE
Pin rack-cache to 1.2 if building for Ruby 1.9

### DIFF
--- a/gemfiles/rails_3.2.gemfile
+++ b/gemfiles/rails_3.2.gemfile
@@ -2,5 +2,6 @@ source "https://rubygems.org"
 
 gem "rails", "3.2.22"
 gem 'test-unit', '3.0.8'
+gem 'rack-cache', '1.2' if RUBY_VERSION == "1.9.3"
 
 gemspec :path=>"../"

--- a/gemfiles/rails_4.0.gemfile
+++ b/gemfiles/rails_4.0.gemfile
@@ -2,5 +2,6 @@ source "https://rubygems.org"
 
 gem "rails", "4.0.8"
 gem 'test-unit', '3.0.8'
+gem 'rack-cache', '1.2' if RUBY_VERSION == "1.9.3"
 
 gemspec :path=>"../"

--- a/gemfiles/rails_4.1.gemfile
+++ b/gemfiles/rails_4.1.gemfile
@@ -1,5 +1,6 @@
 source "https://rubygems.org"
 
 gem "rails", "4.1.4"
+gem 'rack-cache', '1.2' if RUBY_VERSION == "1.9.3"
 
 gemspec :path=>"../"

--- a/gemfiles/rails_4.2.gemfile
+++ b/gemfiles/rails_4.2.gemfile
@@ -1,5 +1,6 @@
 source "https://rubygems.org"
 
 gem "rails", "4.2.4"
+gem 'rack-cache', '1.2' if RUBY_VERSION == "1.9.3"
 
 gemspec :path=>"../"


### PR DESCRIPTION
rack-cache 1.3.0 has been released which removes support for Ruby 1.9.
`gds-sso` itself still supports Ruby 1.9, this dependency comes from
`actionpack` and is pessimistically specified as `~> 1.2`, which
permits `1.3.0`

This change ensures that if we’re building the gem with a fresh
lockfile under Ruby 1.9, we pin rack-cache to a compatible version.
This will not affect behaviour of the gem.