### PR TITLE
Pin `omniauth-oauth2` dependency

### DIFF
--- a/gemfiles/rails_3.2.gemfile
+++ b/gemfiles/rails_3.2.gemfile
@@ -3,5 +3,6 @@ source "https://rubygems.org"
 gem "rails", "3.2.22"
 gem 'test-unit', '3.0.8'
 gem 'rack-cache', '1.2' if RUBY_VERSION == "1.9.3"
+gem 'omniauth-oauth2', '1.3.0'
 
 gemspec :path=>"../"

--- a/gemfiles/rails_4.0.gemfile
+++ b/gemfiles/rails_4.0.gemfile
@@ -3,5 +3,6 @@ source "https://rubygems.org"
 gem "rails", "4.0.8"
 gem 'test-unit', '3.0.8'
 gem 'rack-cache', '1.2' if RUBY_VERSION == "1.9.3"
+gem 'omniauth-oauth2', '1.3.0'
 
 gemspec :path=>"../"

--- a/gemfiles/rails_4.1.gemfile
+++ b/gemfiles/rails_4.1.gemfile
@@ -2,5 +2,6 @@ source "https://rubygems.org"
 
 gem "rails", "4.1.4"
 gem 'rack-cache', '1.2' if RUBY_VERSION == "1.9.3"
+gem 'omniauth-oauth2', '1.3.0'
 
 gemspec :path=>"../"

--- a/gemfiles/rails_4.2.gemfile
+++ b/gemfiles/rails_4.2.gemfile
@@ -2,5 +2,6 @@ source "https://rubygems.org"
 
 gem "rails", "4.2.4"
 gem 'rack-cache', '1.2' if RUBY_VERSION == "1.9.3"
+gem 'omniauth-oauth2', '1.3.0'
 
 gemspec :path=>"../"


### PR DESCRIPTION
This fixes a breakage in CI against the signon/GDS-SSO integration
branches, caused by the bump from `1.3` to `1.4` in the
`omniauth-oauth2` dependency of `omniauth-gds`.

I'll investigate fixing it at source but for now this will unblock the
failing CI jobs upon rebuild.