### PR TITLE
Relase 11.1.0 to pin dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 11.1.0
+
+* Pin dependencies to prevent updating to non-compatible versions
+
 # 11.0.0
 
 * Rerelease of 10.1.0

--- a/lib/gds-sso/version.rb
+++ b/lib/gds-sso/version.rb
@@ -1,5 +1,5 @@
 module GDS
   module SSO
-    VERSION = "11.0.0"
+    VERSION = "11.1.0"
   end
 end


### PR DESCRIPTION
This version pins the dependencies of this gem, to prevent consuming apps from updating to `omniauth-oauth2` 1.4, which is not compatible with signon.