### PR TITLE
Add missing linting attribute

### DIFF
--- a/lib/gds-sso/lint/user_spec.rb
+++ b/lib/gds-sso/lint/user_spec.rb
@@ -37,6 +37,7 @@ RSpec.shared_examples "a gds-sso user class" do
       },
       'extra' => {
         'user' => {
+          'disabled' => false,
           'permissions' => ['signin'],
           'organisation_slug' => 'cabinet-office',
           'organisation_content_id' => '91e57ad9-29a3-4f94-9ab4-5e9ae6d13588'
@@ -49,6 +50,7 @@ RSpec.shared_examples "a gds-sso user class" do
     expect(user.uid).to eq('12345')
     expect(user.name).to eq("Joe Smith")
     expect(user.email).to eq('joe.smith@example.com')
+    expect(user).not_to be_disabled
     expect(user.permissions).to eq(['signin'])
     expect(user.organisation_slug).to eq('cabinet-office')
     expect(user.organisation_content_id).to eq('91e57ad9-29a3-4f94-9ab4-5e9ae6d13588')


### PR DESCRIPTION
`disabled` was introduced but never added to the linter's assertions.