### PR TITLE
Parse ERB when loading configuration YAML

### DIFF
--- a/spec/support/signonotron2_integration_helpers.rb
+++ b/spec/support/signonotron2_integration_helpers.rb
@@ -35,7 +35,9 @@ module Signonotron2IntegrationHelpers
   end
 
   def load_signonotron_fixture(filename)
-    db = YAML.load_file(signon_path + "/config/database.yml")['test']
+    require 'erb'
+    parsed = ERB.new(File.read(signon_path + "/config/database.yml")).result
+    db = YAML.load(parsed)['test']
 
     cmd = "mysql #{db['database']} -u#{db['username']} -p#{db['password']} < #{fixture_file(filename)}"
     system cmd or raise "Error loading signonotron fixture"


### PR DESCRIPTION
Rails parses ERB when loading YAML configuration files. So should we
here since alphagov/signonotron2#467 [0] now demands it.

[0] https://github.com/alphagov/signonotron2/pull/467