### PR TITLE
Release `12.0.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 12.0.0
+
+Breaking changes introduced in #95:
+
+* Drop support for Ruby 1.9.3
+* Drop support for Rails 4.0
+* Add support for Ruby 2.3.0
+
 # 11.2.1
 
 * Use `test` for maximum compatibility of test-unit/minitest `User` linter

--- a/lib/gds-sso/version.rb
+++ b/lib/gds-sso/version.rb
@@ -1,5 +1,5 @@
 module GDS
   module SSO
-    VERSION = "11.2.1"
+    VERSION = "12.0.0"
   end
 end


### PR DESCRIPTION
Including changes from #95 to drop support for unsupported Ruby/Rails versions.