### PR TITLE
Add optional caching for the bearer token

### DIFF
--- a/lib/gds-sso/config.rb
+++ b/lib/gds-sso/config.rb
@@ -1,3 +1,5 @@
+require 'active_support/cache/null_store'
+
 module GDS
   module SSO
     module Config
@@ -17,6 +19,9 @@ module GDS
 
       mattr_accessor :auth_valid_for
       @@auth_valid_for = 20 * 3600
+
+      mattr_accessor :cache
+      @@cache = ActiveSupport::Cache::NullStore.new
 
       def self.user_klass
         user_model.to_s.constantize

--- a/spec/unit/bearer_token_spec.rb
+++ b/spec/unit/bearer_token_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper'
+require 'gds-sso/bearer_token'
+
+describe GDS::SSO::BearerToken do
+  describe '.locate' do
+    it 'creates a new user for a token' do
+      response = {
+        user: {
+          uid: 'asd',
+          email: 'user@example.com',
+          name: 'A Name',
+          permissions: ['signin'],
+          organisation_slug: 'hmrc',
+          organisation_content_id: '67a2b78d-eee3-45b3-80e2-792e7f71cecc',
+        }
+      }
+      response = double(body: {
+        user: {
+          uid: 'asd',
+          email: 'user@example.com',
+          name: 'A Name',
+          permissions: ['signin'],
+          organisation_slug: 'hmrc',
+          organisation_content_id: '67a2b78d-eee3-45b3-80e2-792e7f71cecc',
+        }
+      }.to_json)
+
+
+      allow_any_instance_of(OAuth2::AccessToken).to receive(:get).and_return(response)
+
+      created_user = GDS::SSO::BearerToken.locate('MY-API-TOKEN')
+
+      expect(created_user.email).to eql('user@example.com')
+
+      same_user_again = GDS::SSO::BearerToken.locate('MY-API-TOKEN')
+
+      expect(same_user_again.id).to eql(created_user.id)
+    end
+  end
+end


### PR DESCRIPTION
This allows users to specify a caching adapter to cache the bearer token.