### PR TITLE
Correct bearer token authentication docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,9 +110,11 @@ In addition to the single-sign-on strategy, this gem also allows authorisation
 via a "bearer token". This is used by publishing applications to be authorised
 as a [API user](https://signon.publishing.service.gov.uk/api_users).
 
-To authorise with a bearer token, a request has to be made with a HTTP header.
+To authorise with a bearer token, a request has to be made with the HTTP
+headers:
 
 ```
+Accept: application/json
 Authorization: Bearer your-token-here
 ```
 


### PR DESCRIPTION
Without the `Accept: application/json` header being sent, GDS-SSO
doesn't recognise the request as being API in nature, and will attempt
the regular oauth2 dance. Adding this header ensures the request will
be authenticated using the provided bearer token instead.

This is verified via `GDS::SSO::ApiAccess.api_call?(env)`, for
reference.