### PR TITLE
End support for EOL'd Rails / Ruby

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source "https://rubygems.org"
 gemspec
 
 # Default rails. Overridden in gemfiles during multi-build
-gem 'rails', '4.1.4'
+gem 'rails', '4.2.4'
 
 # Gems added to resolve dependency resolution
 gem 'mechanize', '2.6.0'

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source "https://rubygems.org"
 gemspec
 
 # Default rails. Overridden in gemfiles during multi-build
-gem 'rails', '3.2.22'
+gem 'rails', '4.1.4'
 
 # Gems added to resolve dependency resolution
 gem 'mechanize', '2.6.0'

--- a/gds-sso.gemspec
+++ b/gds-sso.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |s|
   s.executables   = []
   s.require_paths = ["lib"]
 
-  s.add_dependency 'rails', '>= 3.0.0'
+  s.add_dependency 'rails', '>= 4.2.4'
   s.add_dependency 'warden', '~> 1.2'
   s.add_dependency 'oauth2', '~> 1.0'
   s.add_dependency 'omniauth', '~> 1.2'

--- a/gds-sso.gemspec
+++ b/gds-sso.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |s|
   s.license     = 'MIT'
 
   s.rubyforge_project = "gds-sso"
+  s.required_ruby_version = ">= 2.2.2"
 
   s.files         = Dir[
     'app/**/*',

--- a/gemfiles/rails_3.2.gemfile
+++ b/gemfiles/rails_3.2.gemfile
@@ -1,7 +1,0 @@
-source "https://rubygems.org"
-
-gem "rails", "3.2.22"
-gem 'test-unit', '3.0.8'
-gem 'omniauth-oauth2', '1.3.0'
-
-gemspec :path=>"../"

--- a/gemfiles/rails_4.1.gemfile
+++ b/gemfiles/rails_4.1.gemfile
@@ -1,6 +1,0 @@
-source "https://rubygems.org"
-
-gem "rails", "4.1.4"
-gem 'omniauth-oauth2', '1.3.0'
-
-gemspec :path=>"../"

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -13,7 +13,7 @@ rm -f gemfiles/*.gemfile.lock
 # Exclude /tmp from git clean as it only contains the signonotron checkout
 git clean -fdxe /tmp
 
-for ruby_version in 2.1 2.2 2.3; do
+for ruby_version in 2.2 2.3; do
   for gemfile in rails_3.2 rails_4.1 rails_4.2; do
     RBENV_VERSION=${ruby_version} bundle install \
       --path "${HOME}/bundles/${JOB_NAME}" \

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -14,7 +14,7 @@ rm -f gemfiles/*.gemfile.lock
 git clean -fdxe /tmp
 
 for ruby_version in 2.2 2.3; do
-  for gemfile in rails_4.1 rails_4.2; do
+  for gemfile in rails_4.2; do
     RBENV_VERSION=${ruby_version} bundle install \
       --path "${HOME}/bundles/${JOB_NAME}" \
       --gemfile "gemfiles/${gemfile}.gemfile"

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -14,7 +14,7 @@ rm -f gemfiles/*.gemfile.lock
 git clean -fdxe /tmp
 
 for ruby_version in 2.2 2.3; do
-  for gemfile in rails_3.2 rails_4.1 rails_4.2; do
+  for gemfile in rails_4.1 rails_4.2; do
     RBENV_VERSION=${ruby_version} bundle install \
       --path "${HOME}/bundles/${JOB_NAME}" \
       --gemfile "gemfiles/${gemfile}.gemfile"


### PR DESCRIPTION
This ends support for older, unsupported Ruby / Rails versions per #103.

We still iterate `gemfiles` as I'll be adding Rails 5 shortly.