### PR TITLE
Identify API calls via presence of bearer token

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,13 +108,11 @@ end
 
 In addition to the single-sign-on strategy, this gem also allows authorisation
 via a "bearer token". This is used by publishing applications to be authorised
-as a [API user](https://signon.publishing.service.gov.uk/api_users).
+as an [API user](https://signon.publishing.service.gov.uk/api_users).
 
-To authorise with a bearer token, a request has to be made with the HTTP
-headers:
+To authorise with a bearer token, a request has to be made with the header:
 
 ```
-Accept: application/json
 Authorization: Bearer your-token-here
 ```
 

--- a/gds-sso.gemspec
+++ b/gds-sso.gemspec
@@ -37,7 +37,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'omniauth', '~> 1.2'
   s.add_dependency 'omniauth-gds', '~> 3.2'
   s.add_dependency 'warden-oauth2', '~> 0.0.1'
-  s.add_dependency 'rack-accept', '~> 0.4.4'
   s.add_dependency 'multi_json', '~> 1.0'
 
   s.add_development_dependency 'rake',  '0.9.2.2'

--- a/lib/gds-sso/api_access.rb
+++ b/lib/gds-sso/api_access.rb
@@ -1,11 +1,8 @@
-require 'rack/accept'
-
 module GDS
   module SSO
     class ApiAccess
       def self.api_call?(env)
-        request = Rack::Accept::Request.new(env)
-        request.best_media_type(%w{text/html application/json}) == 'application/json'
+        /\ABearer / === env['HTTP_AUTHORIZATION'].to_s
       end
     end
   end

--- a/spec/unit/api_access_spec.rb
+++ b/spec/unit/api_access_spec.rb
@@ -9,7 +9,9 @@ describe GDS::SSO::ApiAccess do
     expect(GDS::SSO::ApiAccess.api_call?('HTTP_ACCEPT' => ie7_accept_header)).to be_false
   end
 
-  it "should consider a json accept header to be an api call" do
-    expect(GDS::SSO::ApiAccess.api_call?('HTTP_ACCEPT' => 'application/json')).to be_true
+  context "with a bearer token" do
+    it "it is considered an api call" do
+      expect(GDS::SSO::ApiAccess.api_call?('HTTP_AUTHORIZATION' => 'Bearer deadbeef12345678')).to be_true
+    end
   end
 end


### PR DESCRIPTION
This change permits authorisation of AJAX-style calls in GDS-SSO
hosting applications via cookie-based sessions.

The bearer token string is matched per:
https://tools.ietf.org/html/rfc6750#section-2.1

Closes alphagov/gds-sso#106.