### PR TITLE
Don't refer to rake when signon wasn't booted

### DIFF
--- a/spec/support/signonotron2_integration_helpers.rb
+++ b/spec/support/signonotron2_integration_helpers.rb
@@ -8,7 +8,7 @@ module Signonotron2IntegrationHelpers
     while ! signonotron_started?(url)
       print '.'
       if retries > 20
-        raise "Signonotron is not running at #{url}. Please start with 'bundle exec rake signonotron:start'. Under jenkins this should have been run automatically"
+        raise "Signonotron is not running at #{url}. Please start with `./start_signon.sh`. Under jenkins this should happen automatically."
       end
       retries += 1
       sleep 1


### PR DESCRIPTION
For integration tests we now start signon with the provided bash
scripts so this message was incorrect.