### PR TITLE
Update signon fixture password

### DIFF
--- a/spec/fixtures/integration/signonotron2.sql
+++ b/spec/fixtures/integration/signonotron2.sql
@@ -18,7 +18,7 @@ INSERT INTO `supported_permissions` (id, application_id, name, created_at, updat
               VALUES (2,2,'signin','2012-04-19 13:26:54','2012-04-19 13:26:54');
 
 INSERT INTO `users` (id, email, encrypted_password, password_salt, created_at, updated_at, confirmed_at, name, uid, role, password_changed_at)
-              VALUES (1,'test@example-client.com','bb8e19edbaa1e7721abe0faa5c1663a7685950093b8c7eceb0f2e3889bdea4c5f17ca97820b2c663edf46ea532d1a9baa04b680fc537b4de8a3f376dd28e3ffd','MpLsZ8q1UaAojTa6bTC6','2012-04-19 13:26:54','2012-04-19 13:26:54','2012-04-19 13:26:54','Test User','integration-uid', "normal", NOW());
+              VALUES (1,'test@example-client.com','3a890fe5e95b328b83f2ba57ea893cae595f4937291ff5550acb68f4a8dafeac22e5f8120c1e66be8f2b769df142dd3d111b404c5c1741595c9ecc9e7e6ad827','QCsZsJs7m5ojdgvysHSy','2012-04-19 13:26:54','2012-04-19 13:26:54','2012-04-19 13:26:54','Test User','integration-uid', "normal", NOW());
 
 INSERT INTO `user_application_permissions` (user_id, application_id, supported_permission_id, created_at, updated_at)
               VALUES (1,1,1,'2012-04-19 13:26:54','2012-04-19 13:26:54');


### PR DESCRIPTION
In alphagov/signonotron2@bceee5dd7208c00697eea801355ab5efd4c2ff0d I changed the test environment to start using a pepper, which more closely mimics production.

This means that the encrypted password in this repo is no longer valid, so I've created a new user at the console with the same password and updated the encrypted values here.

In order to get the tests to pass here I had to temporarily change the CI job to include:

```
export SIGNON_COMMITISH=b7e6803c4cfa5daef215bec7c29946b3b547eb6f
```

Needs to be merged at the same time as alphagov/signonotron2#511.