### PR TITLE
Permit one or more permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,16 @@ private
 end
 ```
 
+`authorise_user!` can be configured to check for multiple permissions:
+
+```ruby
+# fails unless the user has at least one of these permissions
+authorise_user!(any_of: %w(edit create))
+
+# fails unless the user has both of these permissions
+authorise_user!(all_of: %w(edit create))
+```
+
 ### Authorisation for API Users
 
 In addition to the single-sign-on strategy, this gem also allows authorisation

--- a/lib/gds-sso/controller_methods.rb
+++ b/lib/gds-sso/controller_methods.rb
@@ -13,13 +13,26 @@ module GDS
       end
 
 
-      def authorise_user!(permission)
+      def authorise_user!(permissions)
         # Ensure that we're authenticated (and by extension that current_user is set).
         # Otherwise current_user might be nil, and we'd error out
         authenticate_user!
 
-        if not current_user.has_permission?(permission)
-          raise PermissionDeniedException, "Sorry, you don't seem to have the #{permission} permission for this app."
+        case permissions
+        when String
+          unless current_user.has_permission?(permissions)
+            raise PermissionDeniedException, "Sorry, you don't seem to have the #{permissions} permission for this app."
+          end
+        when Hash
+          raise ArgumentError, "Must be either `any_of` or `all_of`" unless permissions.keys.size == 1
+
+          if permissions[:any_of]
+            authorise_user_with_at_least_one_of_permissions!(permissions[:any_of])
+          elsif permissions[:all_of]
+            authorise_user_with_all_permissions!(permissions[:all_of])
+          else
+            raise ArgumentError, "Must be either `any_of` or `all_of`"
+          end
         end
       end
 
@@ -51,6 +64,22 @@ module GDS
 
       def warden
         request.env['warden']
+      end
+
+      private
+
+      def authorise_user_with_at_least_one_of_permissions!(permissions)
+        if permissions.none? { |permission| current_user.has_permission?(permission) }
+          raise PermissionDeniedException,
+            "Sorry, you don't seem to have any of the permissions: #{permissions.to_sentence} for this app."
+        end
+      end
+
+      def authorise_user_with_all_permissions!(permissions)
+        unless permissions.all? { |permission| current_user.has_permission?(permission) }
+          raise PermissionDeniedException,
+            "Sorry, you don't seem to have all of the permissions: #{permissions.to_sentence} for this app."
+        end
       end
     end
   end

--- a/spec/controller/controller_methods_spec.rb
+++ b/spec/controller/controller_methods_spec.rb
@@ -1,0 +1,71 @@
+require 'spec_helper'
+
+RSpec.describe GDS::SSO::ControllerMethods, '#authorise_user!' do
+  class ControllerSpy < ApplicationController
+    include GDS::SSO::ControllerMethods
+
+    def initialize(current_user)
+      @current_user = current_user
+    end
+
+    def authenticate_user!
+      true
+    end
+
+    attr_reader :current_user
+  end
+
+  let(:current_user) { double }
+  let(:expected_error) { GDS::SSO::ControllerMethods::PermissionDeniedException }
+
+  context 'with a single string permission argument' do
+    it 'permits users with the required permission' do
+      allow(current_user).to receive(:has_permission?).with('good').and_return(true)
+
+      expect { ControllerSpy.new(current_user).authorise_user!('good') }.not_to raise_error
+    end
+
+    it 'does not permit the users without the required permission' do
+      allow(current_user).to receive(:has_permission?).with('good').and_return(false)
+
+      expect { ControllerSpy.new(current_user).authorise_user!('good') }.to raise_error(expected_error)
+    end
+  end
+
+  context 'with the `all_of` option' do
+    it 'permits users with all of the required permissions' do
+      allow(current_user).to receive(:has_permission?).with('good').and_return(true)
+      allow(current_user).to receive(:has_permission?).with('bad').and_return(true)
+
+      expect { ControllerSpy.new(current_user).authorise_user!(all_of: %w(good bad)) }.not_to raise_error
+    end
+
+    it 'does not permit users without all of the required permissions' do
+      allow(current_user).to receive(:has_permission?).with('good').and_return(false)
+      allow(current_user).to receive(:has_permission?).with('bad').and_return(true)
+
+      expect { ControllerSpy.new(current_user).authorise_user!(all_of: %w(good bad)) }.to raise_error(expected_error)
+    end
+  end
+
+  context 'with the `any_of` option' do
+    it 'permits users with any of the required permissions' do
+      allow(current_user).to receive(:has_permission?).with('good').and_return(true)
+      allow(current_user).to receive(:has_permission?).with('bad').and_return(false)
+
+      expect { ControllerSpy.new(current_user).authorise_user!(any_of: %w(good bad)) }.not_to raise_error
+    end
+
+    it 'does not permit users without any of the required permissions' do
+      allow(current_user).to receive(:has_permission?).and_return(false)
+
+      expect { ControllerSpy.new(current_user).authorise_user!(any_of: %w(good bad)) }.to raise_error(expected_error)
+    end
+  end
+
+  context 'with none of `any_of` or `all_of`' do
+    it 'raises an `ArgumentError`' do
+      expect { ControllerSpy.new(current_user).authorise_user!(whoops: 'bad') }.to raise_error(ArgumentError)
+    end
+  end
+end


### PR DESCRIPTION
Supports authorisation of a single permission, any of the given
permissions or all of the given permissions:

```ruby
authorise_user!(any_of: %(manager editor))

authorise_user!(all_of: %(manager editor))

authorise_user!('manager')
```

This maintains backwards compatibility with the existing, scalar
permission API - as specified in the final example above.