### PR TITLE
Remove unsupported Rails cruft

### DIFF
--- a/lib/gds-sso/user.rb
+++ b/lib/gds-sso/user.rb
@@ -5,16 +5,6 @@ module GDS
     module User
       extend ActiveSupport::Concern
 
-      def self.below_rails_4?
-        Gem.loaded_specs['rails'] && Gem.loaded_specs['rails'].version < Gem::Version.new("4.0")
-      end
-
-      included do
-        if GDS::SSO::User.below_rails_4? && respond_to?(:attr_accessible)
-          attr_accessible :uid, :email, :name, :permissions, :organisation_slug, :organisation_content_id, :disabled, as: :oauth
-        end
-      end
-
       def has_permission?(permission)
         if permissions
           permissions.include?(permission)
@@ -48,18 +38,10 @@ module GDS
                  self.where(:email => user_params['email']).first
 
           if user
-            if GDS::SSO::User.below_rails_4?
-              user.update_attributes(user_params, as: :oauth)
-            else
-              user.update_attributes(user_params)
-            end
+            user.update_attributes(user_params)
             user
           else # Create a new user.
-            if GDS::SSO::User.below_rails_4?
-              self.create!(user_params, as: :oauth)
-            else
-              self.create!(user_params)
-            end
+            create!(user_params)
           end
         end
       end

--- a/spec/controller/api_user_controller_spec.rb
+++ b/spec/controller/api_user_controller_spec.rb
@@ -29,11 +29,6 @@ describe Api::UserController, type: :controller do
           :name => "SSO Push user",
           :permissions => ["signin", "user_update_permission"] }]
 
-    if GDS::SSO::User.below_rails_4?
-      user_to_update_attrs << { as: :oauth }
-      signon_sso_push_user_attrs << { as: :oauth }
-    end
-
     @user_to_update = User.create!(*user_to_update_attrs)
     @signon_sso_push_user = User.create!(*signon_sso_push_user_attrs)
   end


### PR DESCRIPTION
These checks / behaviours for Rails < 4 are redundant since we ended
support for these versions in e5aaaaf, some time ago.