### PR TITLE
[Do not merge] Identify and validate api calls

### DIFF
--- a/lib/gds-sso/api_access.rb
+++ b/lib/gds-sso/api_access.rb
@@ -2,7 +2,11 @@ module GDS
   module SSO
     class ApiAccess
       def self.api_call?(env)
-        /\ABearer / === env['HTTP_AUTHORIZATION'].to_s
+        env['HTTP_ACCEPT'] == 'application/json'
+      end
+
+      def self.valid_api_call?(env)
+        api_call?(env) && /\ABearer / === env['HTTP_AUTHORIZATION'].to_s
       end
     end
   end

--- a/lib/gds-sso/failure_app.rb
+++ b/lib/gds-sso/failure_app.rb
@@ -11,7 +11,7 @@ module GDS
       include Rails.application.routes.url_helpers
 
       def self.call(env)
-        if ::GDS::SSO::ApiAccess.api_call?(env)
+        if ::GDS::SSO::ApiAccess.valid_api_call?(env)
           [ 401, {'WWW-Authenticate' => %(Bearer error="invalid_token") }, [] ]
         else
           action(:redirect).call(env)

--- a/lib/gds-sso/warden_config.rb
+++ b/lib/gds-sso/warden_config.rb
@@ -43,7 +43,7 @@ end
 
 Warden::Strategies.add(:gds_sso) do
   def valid?
-    ! ::GDS::SSO::ApiAccess.api_call?(env)
+    ! ::GDS::SSO::ApiAccess.valid_api_call?(env)
   end
 
   def authenticate!
@@ -73,7 +73,7 @@ Warden::Strategies.add(:gds_bearer_token, Warden::OAuth2::Strategies::Bearer)
 
 Warden::Strategies.add(:mock_gds_sso) do
   def valid?
-    ! ::GDS::SSO::ApiAccess.api_call?(env)
+    ! ::GDS::SSO::ApiAccess.valid_api_call?(env)
   end
 
   def authenticate!

--- a/spec/unit/api_access_spec.rb
+++ b/spec/unit/api_access_spec.rb
@@ -2,16 +2,48 @@ require 'spec_helper'
 require 'gds-sso/api_access'
 
 describe GDS::SSO::ApiAccess do
-  it "should not consider IE7 accept header as an api call" do
-    ie7_accept_header = 'image/gif, image/x-xbitmap, image/jpeg, image/pjpeg, ' +
-      'application/x-shockwave-flash, application/xaml+xml, application/x-ms-xbap, ' +
-      'application/x-ms-application, */*'
-    expect(GDS::SSO::ApiAccess.api_call?('HTTP_ACCEPT' => ie7_accept_header)).to be_falsey
+  describe "api_call?" do
+    context "with application/json accept header" do
+      it "is considered an api call" do
+        expect(GDS::SSO::ApiAccess.api_call?('HTTP_ACCEPT' => 'application/json')).to be_truthy
+      end
+    end
+
+    context "without application/json accept header" do
+      it "is not considered an api call" do
+        expect(GDS::SSO::ApiAccess.api_call?('HTTP_ACCEPT' => 'text/html')).to be_falsey
+      end
+    end
+
+    it "should not consider IE7 accept header as an api call" do
+      ie7_accept_header = 'image/gif, image/x-xbitmap, image/jpeg, image/pjpeg, ' +
+        'application/x-shockwave-flash, application/xaml+xml, application/x-ms-xbap, ' +
+        'application/x-ms-application, */*'
+      expect(GDS::SSO::ApiAccess.api_call?('HTTP_ACCEPT' => ie7_accept_header)).to be_falsey
+    end
   end
 
-  context "with a bearer token" do
-    it "it is considered an api call" do
-      expect(GDS::SSO::ApiAccess.api_call?('HTTP_AUTHORIZATION' => 'Bearer deadbeef12345678')).to be_truthy
+  describe "valid_api_call?" do
+    let(:headers) { { 'HTTP_ACCEPT' => 'application/json' } }
+
+    context "with a bearer token" do
+      let(:valid_headers) { headers.merge('HTTP_AUTHORIZATION' => 'Bearer deadbeef12345678') }
+
+      it "is considered a valid api call" do
+        expect(GDS::SSO::ApiAccess.valid_api_call?(valid_headers)).to be_truthy
+      end
+    end
+
+    context "without a bearer token" do
+      it "is not considered a valid api call" do
+        expect(GDS::SSO::ApiAccess.valid_api_call?(headers)).to be_falsey
+      end
+    end
+
+    context "without a valid HTTP_ACCEPT header" do
+      it "is not considered a valid api call" do
+        expect(GDS::SSO::ApiAccess.valid_api_call?('HTTP_AUTHORIZATION' => 'Bearer deadbeef12345678')).to be_falsey
+      end
     end
   end
 end


### PR DESCRIPTION
This fell out of upgrading hmrc-manuals-api to Rails 5, the gds-sso bump from 9.3.0 to 13.2.0 indicated a problem.

https://trello.com/c/6EoCMZer/934-upgrade-hmrc-manuals-api-to-a-supported-version-of-rails 

An API call is identified as having the `HTTP_ACCEPT 'application/json'` request header.
A valid API call also has a `HTTP_AUTHORIZATION 'Bearer ...'` request header.

Checking both in various Warden strategies means that json requests with no
bearer token still get treated as api calls because of the accept header.

Do not merge as [we need CI first](https://github.com/alphagov/gds-sso/pull/117)