### PR TITLE
Deprecate require_signin_permission! controller method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Development
+
+* Deprecate `require_signin_permission!`.  The signin permission is no longer
+  optional, and signon itself manages this during oauth handshake (see:
+  [RFC 78](https://github.com/alphagov/govuk-rfcs/blob/8cbb2a0de86de02f54ae37b245e79b46ad62cb6a/rfc-078-re-architect-signin-permissions-in-signon.md))
+
 # 13.2.0
 
 * Remove Rails 3 specific cruft #114

--- a/README.md
+++ b/README.md
@@ -69,17 +69,7 @@ serialize :permissions, Array
 
 [GDS::SSO::ControllerMethods](/lib/gds-sso/controller_methods.rb) provides some useful methods for your application controllers.
 
-To ensure only users who have been granted access to the application can access it use `require_signin_permission!`.
-
-```ruby
-class ApplicationController < ActionController::Base
-  include GDS::SSO::ControllerMethods
-  before_action :require_signin_permission!
-  # ...
-end
-```
-
-If you want to allow access to everyone with an active Signon account, use `authenticate_user!`.
+To make sure that only people with a signon account and permission to use your app are allowed in use `authenticate_user!`.
 
 ```ruby
 class ApplicationController < ActionController::Base
@@ -112,6 +102,8 @@ authorise_user!(any_of: %w(edit create))
 # fails unless the user has both of these permissions
 authorise_user!(all_of: %w(edit create))
 ```
+
+The signon application makes sure that only users who have been granted access to the application can access it (e.g. they have the `signin` permission for your app).  This used to be left up to the applications themselves to check with the `require_signin_permission!` method.  This is now deprecated and can be removed from your controllers.  You should replace it with a call to `authenticate_user!` if you aren't already using that method, otherwise no signon authentication will be performed.
 
 ### Authorisation for API Users
 

--- a/lib/gds-sso/controller_methods.rb
+++ b/lib/gds-sso/controller_methods.rb
@@ -37,6 +37,7 @@ module GDS
       end
 
       def require_signin_permission!
+        ActiveSupport::Deprecation.warn("require_signin_permission! is deprecated and will be removed in a future version.  The signon application checks for signin permission during oauth and it is no longer optional.", caller)
         authorise_user!('signin')
       rescue PermissionDeniedException
         render "authorisations/cant_signin", layout: "unauthorised", status: :forbidden


### PR DESCRIPTION
For: https://trello.com/c/c4bgclDp/195-implement-rfc-78-make-signon-handle-signin-permission-during-oauth

Changes to the signon application to implement
[RFC-78](https://github.com/alphagov/govuk-rfcs/blob/8cbb2a0de86de02f54ae37b245e79b46ad62cb6a/rfc-078-re-architect-signin-permissions-in-signon.md)
mean it signin permission is no longer optional for users accessing an
application via oauth.  Signon itself will make sure the signin permission
has been granted to the user and reject the oauth handshake if they do not
have it.  We deprecate the `require_signin_permission!` method and update
the docs to make this clear.