### PR TITLE
Allow mock SSO in a Rails Production environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Unreleased
 
 * Use the name of signon instead of signonotron2 since it was renamed.
+* Allow running a mock sso session in a Rails production environment via ENV
+  var - to make it easier to test apps in Rails production environment.
 
 # 13.3.0
 

--- a/lib/gds-sso/config.rb
+++ b/lib/gds-sso/config.rb
@@ -28,7 +28,13 @@ module GDS
       end
 
       def self.use_mock_strategies?
-        ['development', 'test'].include?(Rails.env) && ENV['GDS_SSO_STRATEGY'] != 'real'
+        default_strategy = if %w[development test].include?(Rails.env)
+                             "mock"
+                           else
+                             "real"
+                           end
+
+        ENV.fetch("GDS_SSO_STRATEGY", default_strategy) == "mock"
       end
     end
   end


### PR DESCRIPTION
This follows on from https://github.com/alphagov/gds-sso/pull/124 (which I'm expecting will be merged first)

This is to make our applications more 12-factor and to enable developers
to run their applications in Rails Production environment on their own
machines and within the context of [publishing end-to-end tests][].

[publishing end-to-end tests]: https://github.com/alphagov/publishing-e2e-tests