### PR TITLE
Support Rails 5 API only mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Unreleased
+
+* Provide option to run in an api_only mode, which happens implicitly if you
+  are using Rails 5 in api_only mode. This disables the routes and parts of
+  this gem used in the oauth redirect dance.
+
 # 13.4.0
 
 * Use the name of signon instead of signonotron2 since it was renamed.

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,6 +5,7 @@ REPOSITORY = "gds-sso"
 def rubyVersions = [
   "2.2",
   "2.3",
+  "2.4",
 ]
 
 def gemfiles = [

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,8 +8,8 @@ def rubyVersions = [
 ]
 
 def gemfiles = [
-  "rails_4.2",
-  "rails_5.0",
+  "rails_4",
+  "rails_5",
 ]
 
 node {

--- a/README.md
+++ b/README.md
@@ -130,6 +130,18 @@ GDS::SSO.config do |config|
 end
 ```
 
+If you are using a Rails 5 app in
+[api_only](http://guides.rubyonrails.org/api_app.html) mode this gem will
+automatically disable the oauth layers which use session persistence. You can
+configure this gem to be in api_only mode (or not) with:
+
+```ruby
+GDS::SSO.config do |config|
+  # ...
+  # Only support bearer token authentication and send responses in JSON
+  config.api_only = true
+end
+```
 
 ### Use in development mode
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Some of the applications that use this gem:
 
 ## Usage
 
-### Integration with a Rails 3+ app
+### Integration with a Rails 4+ app
 
 To use gds-sso you will need an oAuth client ID and secret for Signon or a compatible system.
 These can be provided by one of the team with admin access to Signon.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  next if GDS::SSO::Config.api_only?
   get '/auth/gds/callback',               to: 'authentications#callback', as: :gds_sign_in
   get '/auth/gds/sign_out',               to: 'authentications#sign_out', as: :gds_sign_out
   get  '/auth/failure',                   to: 'authentications#failure',  as: :auth_failure

--- a/gemfiles/rails_4.gemfile
+++ b/gemfiles/rails_4.gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-gem "rails", "4.2.4"
+gem "rails", "~> 4.2"
 gem 'omniauth-oauth2', '1.3.0'
 
 gemspec :path=>"../"

--- a/gemfiles/rails_5.gemfile
+++ b/gemfiles/rails_5.gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-gem "rails", "5.0.0.1"
+gem "rails", "~> 5.0"
 gem 'omniauth-oauth2', '1.3.0'
 
 gemspec :path=>"../"

--- a/lib/gds-sso.rb
+++ b/lib/gds-sso.rb
@@ -25,6 +25,7 @@ module GDS
       config.before_eager_load { |app| app.reload_routes! }
 
       config.app_middleware.use ::OmniAuth::Builder do
+        next if GDS::SSO::Config.api_only?
         provider :gds, GDS::SSO::Config.oauth_id, GDS::SSO::Config.oauth_secret,
           client_options: {
             site: GDS::SSO::Config.oauth_root_url,

--- a/lib/gds-sso/config.rb
+++ b/lib/gds-sso/config.rb
@@ -23,6 +23,8 @@ module GDS
       mattr_accessor :cache
       @@cache = ActiveSupport::Cache::NullStore.new
 
+      mattr_writer :api_only
+
       def self.user_klass
         user_model.to_s.constantize
       end
@@ -35,6 +37,12 @@ module GDS
                            end
 
         ENV.fetch("GDS_SSO_STRATEGY", default_strategy) == "mock"
+      end
+
+      def self.api_only?
+        config = Rails.configuration
+        default = config.respond_to?(:api_only) ? config.api_only : false
+        @@api_only.nil? ? default : @@api_only
       end
     end
   end

--- a/lib/gds-sso/controller_methods.rb
+++ b/lib/gds-sso/controller_methods.rb
@@ -6,10 +6,17 @@ module GDS
 
       def self.included(base)
         base.rescue_from PermissionDeniedException do |e|
-          render "authorisations/unauthorised", layout: "unauthorised", status: :forbidden, locals: { message: e.message }
+          if GDS::SSO::Config.api_only?
+            render json: { message: e.message }, status: :forbidden
+          else
+            render "authorisations/unauthorised", layout: "unauthorised", status: :forbidden, locals: { message: e.message }
+          end
         end
-        base.helper_method :user_signed_in?
-        base.helper_method :current_user
+
+        unless GDS::SSO::Config.api_only?
+          base.helper_method :user_signed_in?
+          base.helper_method :current_user
+        end
       end
 
 

--- a/spec/requests/end_to_end_spec.rb
+++ b/spec/requests/end_to_end_spec.rb
@@ -198,4 +198,19 @@ describe "Integration of client using GDS-SSO with signon" do
       expect(page.driver.response.status).to eq(401)
     end
   end
+
+  context "when in api_only mode" do
+    around :all do |examples|
+      GDS::SSO::Config.api_only = true
+      Combustion::Application.reload_routes!
+      examples.run
+      GDS::SSO::Config.api_only = false
+      Combustion::Application.reload_routes!
+    end
+
+    specify "accessing without a bearer token is not authorized" do
+      visit "http://#{@client_host}/restricted"
+      expect(page.driver.response.status).to eq(401)
+    end
+  end
 end


### PR DESCRIPTION
These commits introduce support for running this gem without the aspects that are used as part of a session based structure, namely the OAuth redirect dance and session based storage.

This then allows this gem to be included in apps running in a Rails 5 [api only](http://guides.rubyonrails.org/api_app.html) application.