### PR TITLE
Add a note about calling authorise_user! in deprecation method

### DIFF
--- a/lib/gds-sso/controller_methods.rb
+++ b/lib/gds-sso/controller_methods.rb
@@ -44,7 +44,7 @@ module GDS
       end
 
       def require_signin_permission!
-        ActiveSupport::Deprecation.warn("require_signin_permission! is deprecated and will be removed in a future version.  The signon application checks for signin permission during oauth and it is no longer optional.", caller)
+        ActiveSupport::Deprecation.warn("require_signin_permission! is deprecated and will be removed in a future version. The signon application checks for signin permission during oauth and it is no longer optional. Note that your application will still need to call authorise_user! if it doesn't already.", caller)
         authorise_user!('signin')
       rescue PermissionDeniedException
         render "authorisations/cant_signin", layout: "unauthorised", status: :forbidden


### PR DESCRIPTION
This makes the message slightly clearer in that applications which stop using `require_signin_permission!` still need to call `authorise_user!`.