### PR TITLE
WIP: Ensure mock api user has internal_app permission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Unreleased
+
+* Brute force the mock api user's permission so it includes `internal_app` as
+  a permission.
+
 # 13.5.1
 
 * Update the deprecation warning for `require_signin_permission!`.

--- a/spec/unit/mock_bearer_token_spec.rb
+++ b/spec/unit/mock_bearer_token_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper'
+require 'gds-sso/bearer_token'
+
+describe GDS::SSO::MockBearerToken do
+  describe '.brute_force_permissions' do
+    context 'with an empty permissions array' do
+      it 'returns an array with both signin and internal_app' do
+        permissions = []
+        returned_permissions = GDS::SSO::MockBearerToken.brute_force_permissions(permissions: permissions)
+
+        expect(returned_permissions).to contain_exactly('signin', 'internal_app')
+      end
+    end
+
+    context 'with only one permissions' do
+      it 'adds internal_app when signin is already present' do
+        permissions = ['signin']
+        returned_permissions = GDS::SSO::MockBearerToken.brute_force_permissions(permissions: permissions)
+
+        expect(returned_permissions).to contain_exactly('signin', 'internal_app')
+      end
+
+      it 'adds signin when internal_app is already present' do
+        permissions = ['internal_app']
+        returned_permissions = GDS::SSO::MockBearerToken.brute_force_permissions(permissions: permissions)
+
+        expect(returned_permissions).to contain_exactly('signin', 'internal_app')
+      end
+
+      it 'adds both signin and internal_app when neither is present' do
+
+        permissions = ['some_other_permission']
+        returned_permissions = GDS::SSO::MockBearerToken.brute_force_permissions(permissions: permissions)
+
+        expect(returned_permissions).to contain_exactly('signin', 'internal_app', 'some_other_permission')
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
Email alert api runs as an "api only" application and requires the api user to have a permission of `internal_app`. This was included in [PR 345](https://github.com/alphagov/email-alert-api/pull/345).

Brute force the mock api user to include this permission if they do not already have it.

When running on the dev vm, we use a mock api user. If they do not yet exist in the serving application's database, they are created with `signin` permission only. This PR amends that so the user is created with both `signin` and `internal_app` permission.

If the user is already present, then we check that both `signin` and `internal_app` permissions exist for the user. If not, we update their `permission` attribute to include both permissions.


