### PR TITLE
Add mock api permissions config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Unreleased
+
+* Provide option to allow applications to specify extra permissions that the mock api user needs. The functionality updates the dummy api user to include the permissions if they do not currently have those permissions.
+* Update README to include instructions on how to set up the extra permissions for the mock api user.
+
 # 13.5.1
 
 * Update the deprecation warning for `require_signin_permission!`.

--- a/README.md
+++ b/README.md
@@ -163,6 +163,20 @@ Once that's done, set an environment variable when you run your app. e.g.:
 GDS_SSO_STRATEGY=real bundle exec rails s
 ```
 
+### Extra permissions for api users
+
+By default the mock strategies will create a user with `signin` permission.
+
+If your application needs different or extra permissions for access, you can specify this by adding the following to your config:
+
+```ruby
+GDS::SSO.config do |config|
+  # other config here
+  config.additional_mock_permissions_required = ["array", "of", "permissions"]
+```
+
+The mock bearer token will then ensure that the dummy api user has the required permission.
+
 ### Testing in your application
 
 If your app is using `test-unit` or `minitest`, there is a linting test that can verify your `User` model is compatible with `GDS:SSO::User`:

--- a/lib/gds-sso/bearer_token.rb
+++ b/lib/gds-sso/bearer_token.rb
@@ -56,9 +56,13 @@ module GDS
           dummy_api_user.email = "dummyapiuser@domain.com"
           dummy_api_user.uid = "#{rand(10000)}"
           dummy_api_user.name = "Dummy API user created by gds-sso"
-          dummy_api_user.permissions = ["signin"]
-          dummy_api_user.save!
         end
+
+        unless dummy_api_user.has_all_permissions?(GDS::SSO::Config.permissions_for_dummy_api_user)
+          dummy_api_user.permissions = GDS::SSO::Config.permissions_for_dummy_api_user
+        end
+
+        dummy_api_user.save!
         dummy_api_user
       end
     end

--- a/lib/gds-sso/config.rb
+++ b/lib/gds-sso/config.rb
@@ -25,6 +25,12 @@ module GDS
 
       mattr_writer :api_only
 
+      mattr_accessor :additional_mock_permissions_required
+
+      def self.permissions_for_dummy_api_user
+        ["signin"].push(*additional_mock_permissions_required)
+      end
+
       def self.user_klass
         user_model.to_s.constantize
       end

--- a/lib/gds-sso/lint/user_spec.rb
+++ b/lib/gds-sso/lint/user_spec.rb
@@ -28,6 +28,27 @@ RSpec.shared_examples "a gds-sso user class" do
     expect(subject).to respond_to(:remotely_signed_out?)
   end
 
+  describe "#has_all_permissions?" do
+    it "is false when there are no permissions" do
+      subject.update_attributes(permissions: nil)
+      required_permissions = ["signin"]
+      expect(subject.has_all_permissions?(required_permissions)).to be_falsy
+    end
+
+    it "is false when it does not have all required permissions" do
+      subject.update_attributes(permissions: ["signin"])
+      required_permissions = ["signin", "not_granted_permission_one", "not_granted_permission_two"]
+      expect(subject.has_all_permissions?(required_permissions)).to be false
+    end
+
+    it "is true when it has all required permissions" do
+      subject.update_attributes(permissions: ["signin", "internal_app"])
+      required_permissions = ["signin", "internal_app"]
+      expect(subject.has_all_permissions?(required_permissions)).to be true
+    end
+
+  end
+
   specify "the User class and GDS::SSO::User mixin work together" do
     auth_hash = {
       'uid' => '12345',

--- a/lib/gds-sso/user.rb
+++ b/lib/gds-sso/user.rb
@@ -11,6 +11,14 @@ module GDS
         end
       end
 
+      def has_all_permissions?(required_permissions)
+        if permissions
+          required_permissions.all? do |required_permission|
+            permissions.include?(required_permission)
+          end
+        end
+      end
+
       def self.user_params_from_auth_hash(auth_hash)
         {
           'uid' => auth_hash['uid'],

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+
+describe GDS::SSO::Config do
+  describe "#permissions_for_dummy_user" do
+    context "with no additional mock permissions" do
+      it "returns signin" do
+        subject.additional_mock_permissions_required = nil
+        expect(subject.permissions_for_dummy_api_user).to eq(["signin"])
+      end
+    end
+
+    context "with an additional mock permission as a string" do
+      it "returns an array of permissions" do
+        subject.additional_mock_permissions_required = "internal_app"
+        expected_permissions = ["signin", "internal_app"]
+        expect(subject.permissions_for_dummy_api_user).to eq(expected_permissions)
+      end
+    end
+
+    context "with additional mock permissions as an array" do
+      it "returns an array of permissions" do
+        subject.additional_mock_permissions_required = ["another_permission", "yet_another_permission"]
+        expected_permissions = ["signin", "another_permission", "yet_another_permission"]
+        expect(subject.permissions_for_dummy_api_user).to eq(expected_permissions)
+      end
+    end
+  end
+end

--- a/spec/unit/mock_bearer_token_spec.rb
+++ b/spec/unit/mock_bearer_token_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+require 'gds-sso/bearer_token'
+
+describe GDS::SSO::MockBearerToken do
+  it "updates the permissions of the user" do
+    # setup - ensure extra mock permissions required are nil and
+    # call .locate to create the dummy user initially
+    GDS::SSO::Config.additional_mock_permissions_required = nil
+    dummy_user = subject.locate("ABC")
+    expect(dummy_user.permissions).to match_array(["signin"])
+
+    # add an extra permission
+    GDS::SSO::Config.additional_mock_permissions_required = "extra_permission"
+
+    # ensure the dummy user is returned
+    expect(GDS::SSO).to receive(:test_user).and_return(dummy_user)
+
+    # call .locate again...this should update our permissions
+    dummy_user_two = subject.locate("ABC")
+    expect(dummy_user_two.permissions).to match_array(["signin", "extra_permission"])
+  end
+end


### PR DESCRIPTION
Add extra config and code to allow applications to control the permissions that the mock or dummy api user needs in the developer VM.

Currently gds-sso creates mock api users with `signin` permissions.

Email alert api has a new permission called `internal_app` - see [PR 345](https://github.com/alphagov/email-alert-api/pull/345).
. We want a smooth experience in the developer VM, such that developers spinning the app up get a working version without having to debug any permission errors.

This PR enables that by providing:

* A config parameter to specify extra permissions needed by the application
* A method on the config class to return the extra permissions needed for the api user
* A method on the `User` class to determine if the user `has_all_permissions`
* Changes to the `MockBearerToken` to add the extra permissions if needed

The intention being that individual applications can specify their extra required permissions in their `gds-sso` config. This is a more flexible approach than simply hard coding more permissions in here.

Changes to non-api users is left as out of scope for this PR

[Trello](https://trello.com/c/jEBrH6Za/596-add-configurable-mock-api-permissions-to-gds-sso)