### PR TITLE
Add missing `end` to code sample on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ If your application needs different or extra permissions for access, you can spe
 GDS::SSO.config do |config|
   # other config here
   config.additional_mock_permissions_required = ["array", "of", "permissions"]
+end
 ```
 
 The mock bearer token will then ensure that the dummy api user has the required permission.


### PR DESCRIPTION
The code sample for adding extra permissions for api users is missing
the `end` statement in the README. Fix this for visual consistency with
the rest of the README.