### PR TITLE
Remove `require_signin_permission!`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Remove the deprecated `require_signin_permission!` method.
+
 # 13.6.0
 
 * Provide option to allow applications to specify extra permissions that the mock api user needs. The functionality updates the dummy api user to include the permissions if they do not currently have those permissions.

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ authorise_user!(any_of: %w(edit create))
 authorise_user!(all_of: %w(edit create))
 ```
 
-The signon application makes sure that only users who have been granted access to the application can access it (e.g. they have the `signin` permission for your app).  This used to be left up to the applications themselves to check with the `require_signin_permission!` method.  This is now deprecated and can be removed from your controllers.  You should replace it with a call to `authenticate_user!` if you aren't already using that method, otherwise no signon authentication will be performed.
+The signon application makes sure that only users who have been granted access to the application can access it (e.g. they have the `signin` permission for your app).
 
 ### Authorisation for API Users
 

--- a/app/controllers/authentications_controller.rb
+++ b/app/controllers/authentications_controller.rb
@@ -2,7 +2,6 @@ class AuthenticationsController < ActionController::Base
   include GDS::SSO::ControllerMethods
 
   before_action :authenticate_user!, :only => :callback
-  skip_before_action :require_signin_permission!, raise: false
   layout false
 
   def callback

--- a/lib/gds-sso/controller_methods.rb
+++ b/lib/gds-sso/controller_methods.rb
@@ -43,13 +43,6 @@ module GDS
         end
       end
 
-      def require_signin_permission!
-        ActiveSupport::Deprecation.warn("require_signin_permission! is deprecated and will be removed in a future version. The signon application checks for signin permission during oauth and it is no longer optional. Note that your application will still need to call authorise_user! if it doesn't already.", caller)
-        authorise_user!('signin')
-      rescue PermissionDeniedException
-        render "authorisations/cant_signin", layout: "unauthorised", status: :forbidden
-      end
-
       def authenticate_user!
         warden.authenticate!
       end

--- a/spec/internal/app/controllers/example_controller.rb
+++ b/spec/internal/app/controllers/example_controller.rb
@@ -1,7 +1,6 @@
 class ExampleController < ApplicationController
 
   before_action :authenticate_user!, :only => [:restricted, :this_requires_signin_permission]
-  before_action :require_signin_permission!, only: [:this_requires_signin_permission]
 
   def index
     render body: "jabberwocky"


### PR DESCRIPTION
This method has been deprecated, as Signon now performs this function.