### PR TITLE
Set a user agent for the OAuth client

### DIFF
--- a/lib/gds-sso/bearer_token.rb
+++ b/lib/gds-sso/bearer_token.rb
@@ -20,7 +20,12 @@ module GDS
         @oauth_client ||= OAuth2::Client.new(
           GDS::SSO::Config.oauth_id,
           GDS::SSO::Config.oauth_secret,
-          :site => GDS::SSO::Config.oauth_root_url
+          :site => GDS::SSO::Config.oauth_root_url,
+          :connection_opts => {
+            :headers => {
+              :user_agent => "gds-sso/#{GDS::SSO::VERSION} (#{ENV['GOVUK_APP_NAME']})"
+            }
+          }
         )
       end
 


### PR DESCRIPTION
This replaces the default Faraday user agent, providing additional
information about the version of gds-sso in use, and the app the
request is coming from.

I'm trying to determine the origin of some requests to Signon, and
setting a user agent here will hopefully help with that.