### PR TITLE
Allow customising the OAuth Faraday connection options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 * Allow further customising the OAuth2 Faraday connection_opts.
+* Reduce the default open_timeout to 5 seconds.
 
 # 14.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Allow further customising the OAuth2 Faraday connection_opts.
+
 # 14.0.0
 
 * Remove the deprecated `require_signin_permission!` method.

--- a/lib/gds-sso/bearer_token.rb
+++ b/lib/gds-sso/bearer_token.rb
@@ -26,7 +26,7 @@ module GDS
             :headers => {
               :user_agent => "gds-sso/#{GDS::SSO::VERSION} (#{ENV['GOVUK_APP_NAME']})"
             }
-          }
+          }.merge(GDS::SSO::Config.connection_opts)
         )
       end
 

--- a/lib/gds-sso/config.rb
+++ b/lib/gds-sso/config.rb
@@ -28,7 +28,11 @@ module GDS
       mattr_accessor :additional_mock_permissions_required
 
       mattr_accessor :connection_opts
-      @@connection_opts = {}
+      @@connection_opts = {
+        :request => {
+          :open_timeout => 5,
+        }
+      }
 
       def self.permissions_for_dummy_api_user
         ["signin"].push(*additional_mock_permissions_required)

--- a/lib/gds-sso/config.rb
+++ b/lib/gds-sso/config.rb
@@ -27,6 +27,9 @@ module GDS
 
       mattr_accessor :additional_mock_permissions_required
 
+      mattr_accessor :connection_opts
+      @@connection_opts = {}
+
       def self.permissions_for_dummy_api_user
         ["signin"].push(*additional_mock_permissions_required)
       end


### PR DESCRIPTION
To allow for customising options, like timeouts.

Also lower the default connection timeout.

This should help avoid requests queuing up if Signon is temporarily
unavailable, and this change is motivated by a recent issue with this
happening to the Content Store.

