### PR TITLE
Install signon gems in parallel

### DIFF
--- a/start_signon.sh
+++ b/start_signon.sh
@@ -26,7 +26,7 @@ then
   git checkout ${SIGNON_COMMITISH}
 fi
 
-bundle install --path ${APP_ROOT}_bundle
+bundle install --jobs="$(nproc --all)" --path ${APP_ROOT}_bundle
 
 ${GEM_ROOT}/stop_signon.sh
 


### PR DESCRIPTION
To speed up the Jenkins job for running tests.