### PR TITLE
Set a sensible user agent for the Omniauth OAuth2 client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Set a user agent for the Omniauth OAuth2 client.
+
 # 14.2.0
 
 * Allow further customising the OAuth2 Faraday connection_opts.

--- a/lib/gds-sso.rb
+++ b/lib/gds-sso.rb
@@ -1,6 +1,7 @@
 require 'rails'
 
 require 'gds-sso/config'
+require 'gds-sso/version'
 require 'gds-sso/warden_config'
 require 'omniauth'
 require 'omniauth-gds'
@@ -31,6 +32,11 @@ module GDS
             site: GDS::SSO::Config.oauth_root_url,
             authorize_url: "#{GDS::SSO::Config.oauth_root_url}/oauth/authorize",
             token_url: "#{GDS::SSO::Config.oauth_root_url}/oauth/access_token",
+            connection_opts: {
+              headers: {
+                user_agent: "gds-sso/#{GDS::SSO::VERSION} (#{ENV['GOVUK_APP_NAME']})"
+              }
+            }
           }
       end
 


### PR DESCRIPTION
The GDS omniauth strategy defined in the omniauth-gds gem uses
omniauth-oauth2, which uses the oauth2 gem. The OAuth2::Client can be
passed a user agent, otherwise Faraday seems to be used, which isn't
very helpful.