### PR TITLE
Improve the link to more info about GDS on the 'unauthorised' page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Change the link on the 'unauthorised' page to point to modern GOV.UK.
+
 # 14.3.0
 
 * Set a user agent for the Omniauth OAuth2 client.

--- a/app/views/layouts/unauthorised.html.erb
+++ b/app/views/layouts/unauthorised.html.erb
@@ -7,7 +7,7 @@
       <%= yield %>
     </div>
     <div id="footer" class="cf">
-      &copy; <%= Date.today.year %> <a href="http://digital.cabinetoffice.gov.uk/"><abbr title="Government Digital Service">GDS</abbr></a>.
+      &copy; <%= Date.today.year %> <a href="https://www.gov.uk/government/organisations/government-digital-service">Government Digital Service</a>
     </div>
   </body>
 </html>


### PR DESCRIPTION
- I spotted this in the wild when trying to view Collections Publisher
  in Staging. I didn't have permissions. This unstyled error page
  surprised me. As did the link to non-HTTPS
  `digital.cabinet-office.gov.uk`. Thankfully, we have redirects set up,
  but it seemed very odd.
- This changes it to something more modern.
- All of the error pages here could do with some love, but I'm not doing
  that now. ;-)