### PR TITLE
Revert "Bump combustion from 1.1.2 to 1.3.0"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -69,7 +69,7 @@ GEM
     capybara-mechanize (1.11.0)
       capybara (>= 2.4.4, < 4)
       mechanize (~> 2.7.0)
-    combustion (1.3.0)
+    combustion (1.1.2)
       activesupport (>= 3.0.0)
       railties (>= 3.0.0)
       thor (>= 0.14.6)


### PR DESCRIPTION
This reverts commit e825f9e90d6835fa96c077383abbeca8584f224a.