### PR TITLE
Release version 15.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 15.0.0
 
 * BREAKING: Drop support for Rails 4 and Ruby versions < 2.6
 * Change `update_attributes` calls to `update!` to resolve deprecation warnings

--- a/lib/gds-sso/version.rb
+++ b/lib/gds-sso/version.rb
@@ -1,5 +1,5 @@
 module GDS
   module SSO
-    VERSION = "14.3.0"
+    VERSION = "15.0.0"
   end
 end


### PR DESCRIPTION
* BREAKING: Drop support for Rails 4 and Ruby versions < 2.6
* Change `update_attributes` calls to `update!` to resolve deprecation warnings
* Change the link on the 'unauthorised' page to point to modern GOV.UK.