### PR TITLE
Prefix environment variables with GDS_SSO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 16.0.0
+
+* BREAKING: OAUTH_ID environment variable is replaced by GDS_SSO_OAUTH_ID and OAUTH_SECRET is replaced by GDS_SSO_OAUTH_SECRET
+
 # 15.1.0
 
 * Simplify logic to detect and configure API-only apps

--- a/README.md
+++ b/README.md
@@ -107,8 +107,8 @@ end
 
 To use gds-sso in production you will need to setup the following environment variables, which we look for in [the config](https://github.com/alphagov/gds-sso/blob/master/lib/gds-sso/config.rb). You will need to have admin access to Signon to get these.
 
-- OAUTH_ID
-- OAUTH_SECRET
+- GDS_SSO_OAUTH_ID
+- GDS_SSO_OAUTH_SECRET
 
 ### Use in development mode
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Some of the applications that use this gem:
 - Include the gem in your Gemfile:
 
   ```ruby
-  gem 'gds-sso', '<version>'
+  gem 'gds-sso'
   ```
 
 - Create a "users" table in the database: ([example migration with all the necessary fields](https://github.com/alphagov/content-publisher/blob/16c58a40745c1ea61ec241e5aeb702ae15238f98/db/migrate/20160622154200_create_users.rb))

--- a/lib/gds-sso/config.rb
+++ b/lib/gds-sso/config.rb
@@ -12,11 +12,11 @@ module GDS
 
       # OAuth ID
       mattr_accessor :oauth_id
-      @@oauth_id = ENV.fetch("OAUTH_ID", "test-oauth-id")
+      @@oauth_id = ENV.fetch("GDS_SSO_OAUTH_ID", "test-oauth-id")
 
       # OAuth Secret
       mattr_accessor :oauth_secret
-      @@oauth_secret = ENV.fetch("OAUTH_SECRET", "test-oauth-secret")
+      @@oauth_secret = ENV.fetch("GDS_SSO_OAUTH_SECRET", "test-oauth-secret")
 
       # Location of the OAuth server
       mattr_accessor :oauth_root_url

--- a/lib/gds-sso/version.rb
+++ b/lib/gds-sso/version.rb
@@ -1,5 +1,5 @@
 module GDS
   module SSO
-    VERSION = "15.1.0".freeze
+    VERSION = "16.0.0".freeze
   end
 end


### PR DESCRIPTION
This is opened as a draft until the environment variables are active in production.

This prefix makes it easier to understand that these environment variables
are for this particular gem. Currently a GOV.UK app has the OAUTH_ID and
OAUTH_SECRET environment variables but they don't tend to appear in an
apps code as they're used automatically by this gem. By making this
change it makes it clearer they have a purpose for a particular tool.

This approach is consistent with a number of other GOV.UK gems for
example: https://github.com/alphagov/plek#environment-variables and
https://github.com/alphagov/govuk_test#usage