### PR TITLE
Update start_signon git clone branch to main

### DIFF
--- a/start_signon.sh
+++ b/start_signon.sh
@@ -15,7 +15,7 @@ then
   cd ${APP_ROOT}
   git clean -fdx
   git fetch origin
-  git reset --hard origin/master
+  git reset --hard origin/main
 else
   git clone https://github.com/alphagov/signon ${APP_ROOT}
   cd ${APP_ROOT}


### PR DESCRIPTION
Signon's default branch is now called `main`