### PR TITLE
Rubocop linting corrections

### DIFF
--- a/app/controllers/authentications_controller.rb
+++ b/app/controllers/authentications_controller.rb
@@ -12,6 +12,6 @@ class AuthenticationsController < ActionController::Base
 
   def sign_out
     logout
-    redirect_to GDS::SSO::Config.oauth_root_url + "/users/sign_out"
+    redirect_to "#{GDS::SSO::Config.oauth_root_url}/users/sign_out"
   end
 end

--- a/spec/controller/controller_methods_spec.rb
+++ b/spec/controller/controller_methods_spec.rb
@@ -1,20 +1,6 @@
 require "spec_helper"
 
 RSpec.describe GDS::SSO::ControllerMethods, "#authorise_user!" do
-  class ControllerSpy < ApplicationController
-    include GDS::SSO::ControllerMethods
-
-    def initialize(current_user)
-      @current_user = current_user
-    end
-
-    def authenticate_user!
-      true
-    end
-
-    attr_reader :current_user
-  end
-
   let(:current_user) { double }
   let(:expected_error) { GDS::SSO::ControllerMethods::PermissionDeniedException }
 

--- a/spec/support/controller_spy.rb
+++ b/spec/support/controller_spy.rb
@@ -1,0 +1,13 @@
+class ControllerSpy < ApplicationController
+  include GDS::SSO::ControllerMethods
+
+  def initialize(current_user)
+    @current_user = current_user
+  end
+
+  def authenticate_user!
+    true
+  end
+
+  attr_reader :current_user
+end

--- a/spec/support/controller_spy.rb
+++ b/spec/support/controller_spy.rb
@@ -1,9 +1,10 @@
 class ControllerSpy < ApplicationController
   include GDS::SSO::ControllerMethods
-
+  # rubocop:disable Lint/MissingSuper
   def initialize(current_user)
     @current_user = current_user
   end
+  # rubocop:enable Lint/MissingSuper
 
   def authenticate_user!
     true

--- a/spec/support/serializable_user.rb
+++ b/spec/support/serializable_user.rb
@@ -1,0 +1,3 @@
+class SerializableUser
+  include GDS::SSO::User
+end

--- a/spec/support/signon_integration_helpers.rb
+++ b/spec/support/signon_integration_helpers.rb
@@ -37,7 +37,7 @@ module SignonIntegrationHelpers
 
   def load_signon_fixture(filename)
     require "erb"
-    parsed = ERB.new(File.read(signon_path + "/config/database.yml")).result
+    parsed = ERB.new(File.read("#{signon_path}/config/database.yml")).result
     db = YAML.safe_load(parsed, aliases: true)["test"]
 
     cmd = "mysql #{db['database']} -u#{db['username']} -p#{db['password']} < #{fixture_file(filename)}"

--- a/spec/support/test_user.rb
+++ b/spec/support/test_user.rb
@@ -1,0 +1,29 @@
+class TestUser < OpenStruct
+  include GDS::SSO::User
+
+  def self.where(_opts)
+    []
+  end
+
+  def self.create!(options, _scope = {})
+    new(options)
+  end
+
+  def update_attribute(key, value)
+    send("#{key}=".to_sym, value)
+  end
+
+  def update!(options)
+    options.each do |key, value|
+      update_attribute(key, value)
+    end
+  end
+
+  def remotely_signed_out?
+    remotely_signed_out
+  end
+
+  def disabled?
+    disabled
+  end
+end

--- a/spec/unit/session_serialisation_spec.rb
+++ b/spec/unit/session_serialisation_spec.rb
@@ -2,10 +2,6 @@ require "spec_helper"
 require "active_record"
 
 describe Warden::SessionSerializer do
-  class SerializableUser
-    include GDS::SSO::User
-  end
-
   before :each do
     @old_user_model = GDS::SSO::Config.user_model
     GDS::SSO::Config.user_model = SerializableUser

--- a/spec/unit/user_spec.rb
+++ b/spec/unit/user_spec.rb
@@ -31,36 +31,6 @@ describe GDS::SSO::User do
   end
 
   context "making sure that the lint spec is valid" do
-    class TestUser < OpenStruct
-      include GDS::SSO::User
-
-      def self.where(_opts)
-        []
-      end
-
-      def self.create!(options, _scope = {})
-        new(options)
-      end
-
-      def update_attribute(key, value)
-        send("#{key}=".to_sym, value)
-      end
-
-      def update!(options)
-        options.each do |key, value|
-          update_attribute(key, value)
-        end
-      end
-
-      def remotely_signed_out?
-        remotely_signed_out
-      end
-
-      def disabled?
-        disabled
-      end
-    end
-
     let(:described_class) { TestUser }
     it_behaves_like "a gds-sso user class"
   end

--- a/start_signon.sh
+++ b/start_signon.sh
@@ -15,7 +15,7 @@ then
   cd ${APP_ROOT}
   git clean -fdx
   git fetch origin
-  git reset --hard origin/master
+  git reset --hard origin/main
 else
   git clone https://github.com/alphagov/signon ${APP_ROOT}
   cd ${APP_ROOT}


### PR DESCRIPTION
This PR corrects a number of Rubocop linting errors that have been breaking the build.

It also updates Signon's Github branch to `main`  in the start_signon script, which is also needed for a successful build.