### PR TITLE
Bump version 16.0.0 => 16.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 16.0.1
+
+* Fix linting issues
+
 # 16.0.0
 
 * BREAKING: OAUTH_ID environment variable is replaced by GDS_SSO_OAUTH_ID and OAUTH_SECRET is replaced by GDS_SSO_OAUTH_SECRET

--- a/lib/gds-sso/version.rb
+++ b/lib/gds-sso/version.rb
@@ -1,5 +1,5 @@
 module GDS
   module SSO
-    VERSION = "16.0.0".freeze
+    VERSION = "16.0.1".freeze
   end
 end


### PR DESCRIPTION
Bump version 16.0.0 => 16.0.1

Includes linting corrections introduced in https://github.com/alphagov/gds-sso/pull/246