### PR TITLE
Pass allow_other_host: true for external redirects

### DIFF
--- a/app/controllers/authentications_controller.rb
+++ b/app/controllers/authentications_controller.rb
@@ -12,6 +12,6 @@ class AuthenticationsController < ActionController::Base
 
   def sign_out
     logout
-    redirect_to "#{GDS::SSO::Config.oauth_root_url}/users/sign_out"
+    redirect_to "#{GDS::SSO::Config.oauth_root_url}/users/sign_out", allow_other_host: true
   end
 end


### PR DESCRIPTION
Rails 7 by default forbids redirects to external hosts; but in this case it's a known safe URL, so permit it.
