### PR TITLE
Increase token validity period

### DIFF
--- a/spec/fixtures/integration/authorize_api_users.sql
+++ b/spec/fixtures/integration/authorize_api_users.sql
@@ -1,7 +1,7 @@
 DELETE FROM `oauth_access_tokens`;
 
 INSERT INTO oauth_access_tokens (resource_owner_id, application_id, token, refresh_token, expires_in, created_at)
-  VALUES (1, 1, 'caaeb53be5c7277fb0ef158181bfd1537b57f9e3b83eb795be3cd0af6e118b28', '1bc343797483954d7306d67e96687feccdfdaa8b23ed662ae23e2b03e6661d16', 307584000, '2012-06-27 13:57:47');
+  VALUES (1, 1, 'caaeb53be5c7277fb0ef158181bfd1537b57f9e3b83eb795be3cd0af6e118b28', '1bc343797483954d7306d67e96687feccdfdaa8b23ed662ae23e2b03e6661d16', 30758400000, '2012-06-27 13:57:47');
 
 INSERT INTO oauth_access_tokens (resource_owner_id, application_id, token, refresh_token, expires_in, created_at)
-  VALUES (1, 2, '98c72f4da02fdc43398e029d05567542944d2a9b0df3c20b0accd8bd6c5dc728', 'e2da0489a58219fd4f542139909737627874ceacd2af23f5c268ccecb36e85af', 307584000, '2014-07-14 09:06:14');
+  VALUES (1, 2, '98c72f4da02fdc43398e029d05567542944d2a9b0df3c20b0accd8bd6c5dc728', 'e2da0489a58219fd4f542139909737627874ceacd2af23f5c268ccecb36e85af', 30758400000, '2014-07-14 09:06:14');


### PR DESCRIPTION
The tokens have a finite period of validity which has ended in some cases. Ideally we'd use Timecop so that this didn't matter, but the time that matters is in a separate process (the Signon server instance) and so we can't override it that way, so just adding a couple of zeros and pushing the problem 965 years into the future is going to have to suffice.

(Actually, the better better solution would be not to run an instance of signon at all and test in some other way but that's a bigger task.)