### PR TITLE
Use shared workflow to publish gem

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,29 +66,11 @@ jobs:
     steps:
       - run: echo "All matrix tests have passed 🚀"
 
-  release:
+  publish:
     needs: test
-    runs-on: ubuntu-latest
     if: ${{ github.ref == 'refs/heads/main' }}
     permissions:
       contents: write
-    steps:
-      - uses: actions/checkout@v3
-      - uses: ruby/setup-ruby@v1
-        with:
-          rubygems: latest
-      - env:
-          GEM_HOST_API_KEY: ${{ secrets.ALPHAGOV_RUBYGEMS_API_KEY }}
-        run: |
-          VERSION=$(ruby -e "puts eval(File.read('gds-sso.gemspec')).version")
-          GEM_VERSION=$(gem list --exact --remote gds-sso)
-
-          if [ "${GEM_VERSION}" != "gds-sso (${VERSION})" ]; then
-            gem build gds-sso.gemspec
-            gem push "gds-sso-${VERSION}.gem"
-          fi
-
-          if ! git ls-remote --tags --exit-code origin v${VERSION}; then
-            git tag v${VERSION}
-            git push --tags
-          fi
+    uses: alphagov/govuk-infrastructure/.github/workflows/publish-rubygem.yaml@main
+    secrets:
+      GEM_HOST_API_KEY: ${{ secrets.ALPHAGOV_RUBYGEMS_API_KEY }}


### PR DESCRIPTION
We have a shared workflow file in govuk-infrastructure that can be used for common gem release scenarios.