### PR TITLE
Bump to version 17.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 17.0.0
+
+* Drop support for Ruby 2.6 and Rails 5.
+* Permit 2.x versions of oauth2 gem.
+
 # 16.1.0
 
 * Add `allow_other_host: true` to redirects, for improved Rails 7 support.

--- a/lib/gds-sso/version.rb
+++ b/lib/gds-sso/version.rb
@@ -1,5 +1,5 @@
 module GDS
   module SSO
-    VERSION = "16.1.0".freeze
+    VERSION = "17.0.0".freeze
   end
 end


### PR DESCRIPTION
See https://github.com/alphagov/gds-sso/pull/256 and https://github.com/alphagov/gds-sso/pull/255.