### PR TITLE
Fix CI builds and clean up dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,4 @@
-name: Continuous integration
-on:
-  push:
-    branches: [main]
-  pull_request:
-    branches: [main]
+on: [push, pull_request]
 
 jobs:
   # This matrix job runs the test suite against multiple Ruby and Rails versions

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       MYSQL_ALLOW_EMPTY_PASSWORD: true
       BUNDLE_GEMFILE: gemfiles/${{ matrix.gemfile }}.gemfile
       SIGNON_RUBY_VERSION:
-        2.7.6 # should match https://github.com/alphagov/signon/blob/main/.ruby-version
+        3.1.2 # should match https://github.com/alphagov/signon/blob/main/.ruby-version
               # or at least be compatible
     steps:
       - uses: actions/checkout@v3

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,9 +6,6 @@ inherit_mode:
   merge:
     - Exclude
 
-AllCops:
-  TargetRubyVersion: 2.7
-
 # Renaming files from "gds-sso" to "gds_sso" would be a breaking
 # change.
 Naming/FileName:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,6 +6,16 @@ inherit_mode:
   merge:
     - Exclude
 
+# **************************************************************
+# TRY NOT TO ADD OVERRIDES IN THIS FILE
+#
+# This repo is configured to follow the RuboCop GOV.UK styleguide.
+# Any rules you override here will cause this repo to diverge from
+# the way we write code in all other GOV.UK repos.
+#
+# See https://github.com/alphagov/rubocop-govuk/blob/main/CONTRIBUTING.md
+# **************************************************************
+
 # Renaming files from "gds-sso" to "gds_sso" would be a breaking
 # change.
 Naming/FileName:

--- a/Rakefile
+++ b/Rakefile
@@ -1,24 +1,8 @@
-require "bundler/setup"
 require "bundler/gem_tasks"
-
-Bundler::GemHelper.install_tasks
-
 require "rspec/core/rake_task"
-desc "Run all specs"
-RSpec::Core::RakeTask.new(:spec) do |task|
-  task.pattern = "spec/**/*_spec.rb"
-end
+require "rubocop/rake_task"
 
-namespace :spec do
-  desc "Run integration specs"
-  RSpec::Core::RakeTask.new(:integration) do |task|
-    task.pattern = "spec/integration/**/*_spec.rb"
-  end
-end
+RSpec::Core::RakeTask.new(:spec)
+RuboCop::RakeTask.new
 
-desc "Lint Ruby"
-task :lint do
-  sh "bundle exec rubocop --format clang"
-end
-
-task default: %i[spec lint]
+task default: %i[rubocop spec]

--- a/gds-sso.gemspec
+++ b/gds-sso.gemspec
@@ -29,23 +29,20 @@ Gem::Specification.new do |s|
   s.require_paths = %w[lib]
 
   s.add_dependency "multi_json", "~> 1.0"
-  s.add_dependency "oauth2", ">= 1", "< 3"
-  s.add_dependency "omniauth", ">= 1.2", "< 3.0"
+  s.add_dependency "oauth2", "~> 2.0"
+  s.add_dependency "omniauth", "~> 2.1"
   s.add_dependency "omniauth-gds", "~> 3.2"
   s.add_dependency "plek", "~> 4.0"
-  s.add_dependency "rails", ">= 5"
+  s.add_dependency "rails", ">= 6"
   s.add_dependency "warden", "~> 1.2"
   s.add_dependency "warden-oauth2", "~> 0.0.1"
 
   s.add_development_dependency "capybara", "~> 3"
   s.add_development_dependency "capybara-mechanize", "~> 1", ">= 1.12.1" # Require at least 1.12.1 because of compatibility issue with Capybara 3.37.0
-  s.add_development_dependency "combustion", ">= 0.9"
-  s.add_development_dependency "net-smtp", "~> 0.3.1"
-  s.add_development_dependency "rake", ">= 0.9"
-  s.add_development_dependency "rspec-rails", ">= 3"
-  s.add_development_dependency "rubocop-govuk"
-  s.add_development_dependency "sqlite3", "~> 1.4"
-  s.add_development_dependency "timecop", ">= 0.3"
-
-  # Additional development dependencies added to Gemfile to aid dependency resolution.
+  s.add_development_dependency "combustion", "~> 1.3"
+  s.add_development_dependency "rake"
+  s.add_development_dependency "rspec-rails", "~> 6"
+  s.add_development_dependency "rubocop-govuk", "4.7.0"
+  s.add_development_dependency "sqlite3", "~> 1.5"
+  s.add_development_dependency "timecop", "~> 0.9"
 end

--- a/gds-sso.gemspec
+++ b/gds-sso.gemspec
@@ -37,8 +37,8 @@ Gem::Specification.new do |s|
   s.add_dependency "warden", "~> 1.2"
   s.add_dependency "warden-oauth2", "~> 0.0.1"
 
-  s.add_development_dependency "capybara", ">= 2"
-  s.add_development_dependency "capybara-mechanize", ">= 1"
+  s.add_development_dependency "capybara", "~> 3"
+  s.add_development_dependency "capybara-mechanize", "~> 1", ">= 1.12.1" # Require at least 1.12.1 because of compatibility issue with Capybara 3.37.0
   s.add_development_dependency "combustion", ">= 0.9"
   s.add_development_dependency "net-smtp", "~> 0.3.1"
   s.add_development_dependency "rake", ">= 0.9"

--- a/gemfiles/rails_6.gemfile
+++ b/gemfiles/rails_6.gemfile
@@ -1,5 +1,6 @@
 source "https://rubygems.org"
 
+gem "net-smtp" # Ruby 3.1 removed this gem from stdlib, so Rails 6 needs it as an explicit dependency
 gem "rails", "~> 6.0"
 
 gemspec path: "../"


### PR DESCRIPTION
Trello: https://trello.com/c/QrxjshEm/270-move-ruby-gems-from-jenkins-to-github-actions

This fixes CI which is not currently building for branches other than main (and even then was failing). It has a few other TLC tasks done to this gem.

This has been done as a precursor to merging the [omniauth-gds](https://github.com/alphagov/omniauth-gds) into this gem and archiving that gem (to reduce number of gems that are maintained).

Best reviewed commit by commit.