### PR TITLE
Merge omniauth-gds into this gem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Merge [omniauth-gds](https://github.com/alphagov/omniauth-gds) gem into this codebase, ahead of that gem's retirement.
+
 # 17.0.0
 
 * Drop support for Ruby 2.6 and Rails 5.

--- a/gds-sso.gemspec
+++ b/gds-sso.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |s|
   s.add_dependency "multi_json", "~> 1.0"
   s.add_dependency "oauth2", "~> 2.0"
   s.add_dependency "omniauth", "~> 2.1"
-  s.add_dependency "omniauth-gds", "~> 3.2"
+  s.add_dependency "omniauth-oauth2", "~> 1.8"
   s.add_dependency "plek", "~> 4.0"
   s.add_dependency "rails", ">= 6"
   s.add_dependency "warden", "~> 1.2"

--- a/gds-sso.gemspec
+++ b/gds-sso.gemspec
@@ -28,7 +28,6 @@ Gem::Specification.new do |s|
   s.executables   = []
   s.require_paths = %w[lib]
 
-  s.add_dependency "multi_json", "~> 1.0"
   s.add_dependency "oauth2", "~> 2.0"
   s.add_dependency "omniauth", "~> 2.1"
   s.add_dependency "omniauth-oauth2", "~> 1.8"

--- a/lib/gds-sso.rb
+++ b/lib/gds-sso.rb
@@ -4,7 +4,7 @@ require "gds-sso/config"
 require "gds-sso/version"
 require "gds-sso/warden_config"
 require "omniauth"
-require "omniauth-gds"
+require "omniauth/strategies/gds"
 
 require "gds-sso/railtie" if defined?(Rails)
 

--- a/lib/gds-sso/bearer_token.rb
+++ b/lib/gds-sso/bearer_token.rb
@@ -1,4 +1,4 @@
-require "multi_json"
+require "json"
 require "oauth2"
 require "gds-sso/version"
 
@@ -35,7 +35,7 @@ module GDS
       # structure. Here we're addressing signon directly so
       # we need to transform the response ourselves.
       def self.omniauth_style_response(response_body)
-        input = MultiJson.decode(response_body)["user"]
+        input = JSON.parse(response_body).fetch("user")
 
         {
           "uid" => input["uid"],

--- a/lib/omniauth/strategies/gds.rb
+++ b/lib/omniauth/strategies/gds.rb
@@ -1,0 +1,26 @@
+require "omniauth-oauth2"
+require "multi_json"
+
+class OmniAuth::Strategies::Gds < OmniAuth::Strategies::OAuth2
+  uid { user["uid"] }
+
+  info do
+    {
+      name: user["name"],
+      email: user["email"],
+    }
+  end
+
+  extra do
+    {
+      user: user,
+      permissions: user["permissions"],
+      organisation_slug: user["organisation_slug"],
+      organisation_content_id: user["organisation_content_id"],
+    }
+  end
+
+  def user
+    @user ||= MultiJson.decode(access_token.get("/user.json?client_id=#{CGI.escape(options.client_id)}").body)["user"]
+  end
+end

--- a/lib/omniauth/strategies/gds.rb
+++ b/lib/omniauth/strategies/gds.rb
@@ -1,5 +1,5 @@
 require "omniauth-oauth2"
-require "multi_json"
+require "json"
 
 class OmniAuth::Strategies::Gds < OmniAuth::Strategies::OAuth2
   uid { user["uid"] }
@@ -21,6 +21,6 @@ class OmniAuth::Strategies::Gds < OmniAuth::Strategies::OAuth2
   end
 
   def user
-    @user ||= MultiJson.decode(access_token.get("/user.json?client_id=#{CGI.escape(options.client_id)}").body)["user"]
+    @user ||= JSON.parse(access_token.get("/user.json?client_id=#{CGI.escape(options.client_id)}").body).fetch("user")
   end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/QrxjshEm/270-move-ruby-gems-from-jenkins-to-github-actions

This merges the [omniauth-gds](https://github.com/alphagov/omniauth-gds) gem into this app. I did this as it seemed unnecessary to have a gem for a single file that's basically coupled to this gem and wasn't tested. It also helps reduce our gem overhead. It also removes the multi_json dependency which didn't seem needed.

Once merged I'll be looking to archive the omniauth-gds gem.