### PR TITLE
Update Plek support to allow version 5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 17.1.1
+
+* Update Plek support to allow version 5
+
 # 17.1.0
 
 * Merge [omniauth-gds](https://github.com/alphagov/omniauth-gds) gem into this codebase, ahead of that gem's retirement.

--- a/gds-sso.gemspec
+++ b/gds-sso.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |s|
   s.add_dependency "oauth2", "~> 2.0"
   s.add_dependency "omniauth", "~> 2.1"
   s.add_dependency "omniauth-oauth2", "~> 1.8"
-  s.add_dependency "plek", "~> 4.0"
+  s.add_dependency "plek", ">= 4", "< 6"
   s.add_dependency "rails", ">= 6"
   s.add_dependency "warden", "~> 1.2"
   s.add_dependency "warden-oauth2", "~> 0.0.1"

--- a/lib/gds-sso/version.rb
+++ b/lib/gds-sso/version.rb
@@ -1,5 +1,5 @@
 module GDS
   module SSO
-    VERSION = "17.1.0".freeze
+    VERSION = "17.1.1".freeze
   end
 end


### PR DESCRIPTION
This updates the constraints on Plek so that version 5 can be used, which is compatible with this gem.

In time we should drop support for v4 but this is currently unnecessary as it remains compatible.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

