### PR TITLE
Relax constraint on rubocop-govuk dependency

### DIFF
--- a/gds-sso.gemspec
+++ b/gds-sso.gemspec
@@ -40,7 +40,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "combustion", "~> 1.3"
   s.add_development_dependency "rake"
   s.add_development_dependency "rspec-rails", "~> 6"
-  s.add_development_dependency "rubocop-govuk", "4.12.0"
+  s.add_development_dependency "rubocop-govuk", "~> 4"
   s.add_development_dependency "sqlite3", "~> 1.5"
   s.add_development_dependency "timecop", "~> 0.9"
   s.add_development_dependency "webmock"


### PR DESCRIPTION
In #261 (specifically [this commit][1]), most of the dependency constraints were relaxed to use [pessimistic constraints][2]. For some reason this gem was pinned at 4.7.0, but there's no explanation in the commit note or the PR description.

Since Rubocop seems to run OK with the latest v4 of rubocop-govuk, I think it makes sense to relax this constraint. This should mean we don't keep getting Dependabot PRs for every patch version of rubocop-govuk.

[1]: https://github.com/alphagov/gds-sso/commit/0161fdf616508f114951c60bebba91dab685454b
[2]: https://thoughtbot.com/blog/rubys-pessimistic-operator
