### PR TITLE
Bump version to v18.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## Unreleased
 
-* Drop support for Ruby 2.7.
+# 18.0.0
+
+* Drop support for Ruby 2.7. (#277)
+* Relax rubocop-govuk dependency constraint to ~> 4. (#280)
 
 # 17.1.1
 

--- a/lib/gds-sso/version.rb
+++ b/lib/gds-sso/version.rb
@@ -1,5 +1,5 @@
 module GDS
   module SSO
-    VERSION = "17.1.1".freeze
+    VERSION = "18.0.0".freeze
   end
 end


### PR DESCRIPTION
This includes the following two changes:

* Drop support for Ruby 2.7. (#277)
* Relax rubocop-govuk dependency constraint to ~> 4. (#280)

I've elected to do a major version bump, because of the dropping of support for Ruby 2.7.

It's my reading of the following code, that if this is merged and all the tests pass then a new version of the gem will automatically be published.

https://github.com/alphagov/gds-sso/blob/af8df2c7e60f33ed6ffaf7b01e453520a45a7edc/.github/workflows/ci.yml#L33-L40

https://github.com/alphagov/govuk-infrastructure/blob/299781c687332f81a72013a62cfcee26bb2a0302/.github/workflows/publish-rubygem.yml#L63-L68


