### PR TITLE
 Enable PKCE extension in GDS OmniAuth Strategy 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+* Enable [OAuth2 PKCE extension](https://datatracker.ietf.org/doc/html/rfc7636) in the GDS OAuth2 OmniAuth Strategy. The [PKCE extension was enabled in Signon in PR 2312](https://github.com/alphagov/signon/pull/2312).
+
 # 18.0.0
 
 * Drop support for Ruby 2.7. (#277)

--- a/lib/omniauth/strategies/gds.rb
+++ b/lib/omniauth/strategies/gds.rb
@@ -4,6 +4,8 @@ require "json"
 class OmniAuth::Strategies::Gds < OmniAuth::Strategies::OAuth2
   uid { user["uid"] }
 
+  option :pkce, true
+
   info do
     {
       name: user["name"],


### PR DESCRIPTION
https://trello.com/c/59EBweBx

In https://github.com/alphagov/signon/pull/2312 we enabled the OAuth2 [PKCE extension][1] in Signon.

In this PR we update the GDS OAuth2 OmniAuth Strategy to make use of the PKCE extension. This means that any of our apps using this Gem will benefit from the additional protection offered by the PKCE extension.

## Testing this change in development

Create an app in Signon representing Whitehall Publisher.

```
$ cd ~/govuk/signon
$ gdr rails c
irb> app = Doorkeeper::Application.create!(name: 'Whitehall dev', redirect_uri: 'http://whitehall-admin.dev.gov.uk/auth/gds/callback')
```

Give our test user permission to access Whitehall Publisher.

```
irb> app = Doorkeeper::Application.find_by(name: 'Whitehall dev')
irb> user = User.find_by(email: 'test.user@gov.uk')
irb> user.supported_permissions << app.supported_permissions
```

Set the following environment variables for the whitehall-app container in govuk-docker/projects/whitehall/docker-compose.yml, where `<oauth-id>` is `app.uid` and `<oauth-secret>` is `app.secret`.

```
$ vim ~/govuk/govuk-docker/projects/whitehall/docker-compose.yml

GDS_SSO_OAUTH_ID: "<oauth-id>"
GDS_SSO_OAUTH_SECRET: "<oauth-secret>"
GDS_SSO_STRATEGY: "real"
```

Modify Whitehall's Gemfile and install Gems:

```
-gem "gds-sso"
+gem "gds-sso", git: "https://github.com/alphagov/gds-sso.git", branch: "add-pkce"

$ gdr bundle
```

Now when you sign in to Signon and access Whitehall Publisher in development you'll be able to see the following PKCE related params in the Signon logs:

- the request for /oauth/authorize includes a `code_challenge` and `code_challenge_method` in the querystring
- the request for /oauth/access_token includes the `code_verifier` in the POSTed body 

[1]: https://datatracker.ietf.org/doc/html/rfc7636