### PR TITLE
Release 18.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+# 18.1.0
+
 * Enable [OAuth2 PKCE extension](https://datatracker.ietf.org/doc/html/rfc7636) in the GDS OAuth2 OmniAuth Strategy. The [PKCE extension was enabled in Signon in PR 2312](https://github.com/alphagov/signon/pull/2312).
 
 # 18.0.0

--- a/lib/gds-sso/version.rb
+++ b/lib/gds-sso/version.rb
@@ -1,5 +1,5 @@
 module GDS
   module SSO
-    VERSION = "18.0.0".freeze
+    VERSION = "18.1.0".freeze
   end
 end


### PR DESCRIPTION
This includes the following addition:

- Enable PKCE extension in GDS OmniAuth Strategy #283

This is backward compatible additional functionality so I've made it a minor release.
