### PR TITLE
Add Rails 7.1 to CI test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
         # Due to https://github.com/actions/runner/issues/849, we have to use quotes for '3.0'
         ruby: ['3.0', 3.1, 3.2]
         # Test against multiple Rails versions
-        gemfile: [rails_6, rails_7]
+        gemfile: [rails_6, rails_7, rails_7_1]
     runs-on: ubuntu-latest
     env:
       BUNDLE_GEMFILE: gemfiles/${{ matrix.gemfile }}.gemfile

--- a/gemfiles/rails_7_1.gemfile
+++ b/gemfiles/rails_7_1.gemfile
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+
+gem "rails", "~> 7.1"
+
+gemspec path: "../"


### PR DESCRIPTION
Dependabot has started upgrading our Rails apps to 7.1 so we should ensure that gds-sso also works as expected.
