### PR TITLE
Avoid deprecation warning in specs

### DIFF
--- a/spec/internal/app/models/user.rb
+++ b/spec/internal/app/models/user.rb
@@ -1,5 +1,5 @@
 class User < ActiveRecord::Base
   include GDS::SSO::User
 
-  serialize :permissions, Array
+  serialize :permissions, type: Array
 end


### PR DESCRIPTION
> DEPRECATION WARNING: Passing the class as positional argument is
> deprecated and will be removed in Rails 7.2.
>
> Please pass the class as a keyword argument:
>
> serialize :permissions, type: Array
