### PR TITLE
Remove redundant `cant_signin` template

### DIFF
--- a/app/views/authorisations/cant_signin.html.erb
+++ b/app/views/authorisations/cant_signin.html.erb
@@ -1,6 +1,0 @@
-<h1>Sorry, you don't have permission to access this application</h1>
-
-<p>Please contact your Delivery Manager or main GDS contact if you need access.</p>
-
-<p>If you think something is wrong, try <%= link_to "signing out", gds_sign_out_path %> and then back in.</p>
-


### PR DESCRIPTION
The route & action (but not the template) was removed in [this commit][1] and the template should've been removed at the same time.

[1]: https://github.com/alphagov/gds-sso/commit/07444197b6109acf286a88029010520345d524b2
