### PR TITLE
Configure Dependabot to update all RubyGems

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
   directory: "/"
   schedule:
     interval: daily
+  allow:
+    - dependency-type: "all"
 - package-ecosystem: "github-actions"
   directory: "/"
   schedule:


### PR DESCRIPTION
By default Dependabot only monitors direct dependencies (those specified in the Gemfile) for updates. It appears to use `bundle update <dependency>` under the hood, which means that a Dependabot PR to update <dependency> can also include updates to sub-dependencies. This makes it harder to review because the PR will only include the Changelog of <dependency> and not of the sub-dependencies.

My hope is that by configuring Dependabot to [monitor direct and indirect (sub) dependencies][1] we'll end up with more, smaller/easier to review, PRs.

I think the [same change][2] has been working reasonably well in Signon and thought it was worth bringing gds-sso into line.

[1]: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#allow
[2]: https://github.com/alphagov/signon/pull/2382
