### PR TITLE
Fix deprecation warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## Unreleased
 
+# 19.0.0
+
+* We no longer set `ActiveSupport::Cache::NullStore.new` as the default cache. This avoids a deprecation warning when the gem is used in Rails apps.
+  * If you're using `gds-sso` in a Rails app and [relying on the Railtie](https://github.com/alphagov/gds-sso/blob/main/lib/gds-sso/railtie.rb#L6) to set the cache then you don't need to do anything
+  * If you're using `gds-sso` and manually setting the cache then you don't need to do anything.
+  * If you're using `gds-sso` outside of a Rails app and you're not explicitly setting the cache then you'll need to configure it before you can use `GDS::SSO::BearerToken.locate`.
+
 # 18.1.0
 
 * Enable [OAuth2 PKCE extension](https://datatracker.ietf.org/doc/html/rfc7636) in the GDS OAuth2 OmniAuth Strategy. The [PKCE extension was enabled in Signon in PR 2312](https://github.com/alphagov/signon/pull/2312).

--- a/lib/gds-sso/config.rb
+++ b/lib/gds-sso/config.rb
@@ -26,7 +26,6 @@ module GDS
       @@auth_valid_for = 20 * 3600
 
       mattr_accessor :cache
-      @@cache = ActiveSupport::Cache::NullStore.new
 
       mattr_accessor :api_only
 

--- a/lib/gds-sso/version.rb
+++ b/lib/gds-sso/version.rb
@@ -1,5 +1,5 @@
 module GDS
   module SSO
-    VERSION = "18.1.0".freeze
+    VERSION = "19.0.0".freeze
   end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/qdYyg10D

The presence of this default value for @@cache was causing the
following deprecation warning when the gem was required in other apps:

    DEPRECATION WARNING: Support for
    `config.active_support.cache_format_version = 6.1` has been
    deprecated and will be removed in Rails 7.2.

This is because a newer cache format has been introduced[1].

This configuration option is rarely used across alphagov[2]. When it
is used it is only to set the value to `Rails.cache`. The railtie
`lib/gds-sso/railte.rb` already does this when the gem is used in
Rails applications.

We need to bump the major version of this gem however, since this
change could theoretically cause a change in behaviour.

[1] https://guides.rubyonrails.org/upgrading_ruby_on_rails.html#new-activesupport-cache-serialization-format
[2]
https://github.com/search?q=org%3Aalphagov+%22config.cache+%3D+%22&type=code

