### PR TITLE
Add missing require 'ostruct' in failing spec

### DIFF
--- a/spec/support/test_user.rb
+++ b/spec/support/test_user.rb
@@ -1,3 +1,5 @@
+require "ostruct"
+
 class TestUser < OpenStruct
   include GDS::SSO::User
 


### PR DESCRIPTION
- Whenever we call Openstruct it is now required to explicitly require the library

part of this card: https://trello.com/c/qb1qpwnr/1369-additional-functionality-to-gds-sso-gem-for-intercepting-401s-and-providing-a-route-constraint
