### PR TITLE
Edit .gitignore to ignore different name variants of combustion sqlite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,5 @@ gemfiles/*.lock
 Gemfile.lock
 pkg/*
 tmp/*
-*.sqlite
+*.sqlite*
 spec/internal/tmp


### PR DESCRIPTION
- Combustion gem seems to be creating a couple of different named versions of sqlite test DBs when we run rspec, such as `*.sqlite-wal`

<img width="366" alt="Screenshot 2024-04-23 at 11 09 46" src="https://github.com/alphagov/gds-sso/assets/8425834/e72c34cc-ae0a-46cd-905b-9a05bc2ebf41">
