### PR TITLE
Encapsulate authenticate user code to a class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+* Introduce GDS::SSO.authenticate_user! method to encapsulate the authentication code for re-use.
+
 ## 20.0.0
 
 * BREAKING: Drop support for Ruby 3.1 [PR](https://github.com/alphagov/gds-sso/pull/318)

--- a/lib/gds-sso.rb
+++ b/lib/gds-sso.rb
@@ -25,6 +25,12 @@ module GDS
       yield GDS::SSO::Config
     end
 
+    def self.authenticate_user!(warden)
+      warden.authenticate! if !warden.authenticated? || warden.user.remotely_signed_out?
+
+      warden.user
+    end
+
     class Engine < ::Rails::Engine
       # Force routes to be loaded if we are doing any eager load.
       # TODO - check this one - Stolen from Devise because it looked sensible...

--- a/lib/gds-sso/authorised_user_constraint.rb
+++ b/lib/gds-sso/authorised_user_constraint.rb
@@ -6,10 +6,9 @@ module GDS
       end
 
       def matches?(request)
-        warden = request.env["warden"]
-        warden.authenticate! if !warden.authenticated? || warden.user.remotely_signed_out?
+        user = GDS::SSO.authenticate_user!(request.env["warden"])
 
-        GDS::SSO::AuthoriseUser.call(warden.user, permissions)
+        GDS::SSO::AuthoriseUser.call(user, permissions)
         true
       end
 

--- a/spec/unit/authorised_user_constraint_spec.rb
+++ b/spec/unit/authorised_user_constraint_spec.rb
@@ -3,48 +3,25 @@ require "gds-sso/authorised_user_constraint"
 
 describe GDS::SSO::AuthorisedUserConstraint do
   before do
+    allow(GDS::SSO).to receive(:authenticate_user!).and_return(user)
     allow(GDS::SSO::AuthoriseUser).to receive(:call).and_return(true)
   end
 
   describe "#matches?" do
-    let(:user) { double("user", remotely_signed_out?: remotely_signed_out) }
-    let(:warden) do
-      double(
-        "warden",
-        authenticated?: user_authenticated,
-        user:,
-        authenticate!: nil,
-      )
-    end
-    let(:user_authenticated) { true }
-    let(:remotely_signed_out) { false }
+    let(:user) { TestUser.new }
+    let(:warden) { instance_double("Warden::Proxy") }
     let(:request) { double("request", env: { "warden" => warden }) }
 
-    it "authorises the user" do
-      expect(GDS::SSO::AuthoriseUser).to receive(:call).with(warden.user, %w[signin])
-      expect(warden).not_to receive(:authenticate!)
+    it "authenticates the user" do
+      expect(GDS::SSO).to receive(:authenticate_user!).with(warden)
 
       described_class.new(%w[signin]).matches?(request)
     end
 
-    context "when the user is not authenticated" do
-      let(:user_authenticated) { false }
+    it "authorises the user" do
+      expect(GDS::SSO::AuthoriseUser).to receive(:call).with(user, %w[signin])
 
-      it "authenticates the user" do
-        expect(warden).to receive(:authenticate!)
-
-        described_class.new(%w[signin]).matches?(request)
-      end
-    end
-
-    context "when the user is remotely signed out" do
-      let(:remotely_signed_out) { true }
-
-      it "authenticates the user" do
-        expect(warden).to receive(:authenticate!)
-
-        described_class.new(%w[signin]).matches?(request)
-      end
+      described_class.new(%w[signin]).matches?(request)
     end
   end
 end

--- a/spec/unit/gds_sso_spec.rb
+++ b/spec/unit/gds_sso_spec.rb
@@ -1,0 +1,37 @@
+require "spec_helper"
+
+describe GDS::SSO do
+  describe "#authenticate_user!" do
+    let(:user) { TestUser.new }
+    let(:warden) do
+      instance_double("Warden::Proxy",
+                      authenticate!: true,
+                      authenticated?: false,
+                      user:)
+    end
+
+    context "when a user is not already authenticated" do
+      it "authenticates the user and returns the user object" do
+        expect(described_class.authenticate_user!(warden)).to be(user)
+        expect(warden).to have_received(:authenticate!)
+      end
+    end
+
+    context "when a user is already authenticated and not remotely signed out" do
+      it "doesn't reauthenticate the user" do
+        allow(warden).to receive(:authenticated?).and_return(true)
+        expect(described_class.authenticate_user!(warden)).to be(user)
+
+        expect(warden).not_to have_received(:authenticate!)
+      end
+    end
+
+    context "when a user is already authenticated and remotely signed out" do
+      it "authenticates the user again" do
+        user.remotely_signed_out = true
+        expect(described_class.authenticate_user!(warden)).to be(user)
+        expect(warden).to have_received(:authenticate!)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Trello: https://trello.com/c/cZXuUL56/2578-can-we-rate-limit-by-signon-user-id

This moves the rather basic code for authenticating a user into a standalone class. The motivation for this is so that this check can be used without logic repetition. The use case I have intended is to use this code as part of Rack middleware so that we can authenticate a user before running other middleware (Rack::Attack rate limiting middleware).

This repo is owned by the publishing access & permissions team. Please let us know in #govuk-publishing-access-and-permissions-team when you raise any PRs.
