### PR TITLE
Return GDS::SSO.test_user without modifications for MockBearerToken

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* BREAKING: MockBearerToken returns a specified GDS::SSO.test_user without permission modifications to allow testing different permissions
 * Introduce GDS::SSO.authenticate_user! method to encapsulate the authentication code for re-use.
 
 ## 20.0.0

--- a/lib/gds-sso/bearer_token.rb
+++ b/lib/gds-sso/bearer_token.rb
@@ -56,7 +56,9 @@ module GDS
 
     module MockBearerToken
       def self.locate(_token_string)
-        dummy_api_user = GDS::SSO.test_user || GDS::SSO::Config.user_klass.where(email: "dummyapiuser@domain.com").first
+        return GDS::SSO.test_user if GDS::SSO.test_user
+
+        dummy_api_user = GDS::SSO::Config.user_klass.where(email: "dummyapiuser@domain.com").first
         if dummy_api_user.nil?
           dummy_api_user = GDS::SSO::Config.user_klass.new
           dummy_api_user.email = "dummyapiuser@domain.com"

--- a/spec/unit/mock_bearer_token_spec.rb
+++ b/spec/unit/mock_bearer_token_spec.rb
@@ -2,21 +2,54 @@ require "spec_helper"
 require "gds-sso/bearer_token"
 
 describe GDS::SSO::MockBearerToken do
-  it "updates the permissions of the user" do
-    # setup - ensure extra mock permissions required are nil and
-    # call .locate to create the dummy user initially
-    GDS::SSO::Config.additional_mock_permissions_required = nil
-    dummy_user = subject.locate("ABC")
-    expect(dummy_user.permissions).to match_array(%w[signin])
+  describe ".locate" do
+    it "returns a GDS::SSO.test_user if one is set" do
+      test_user = TestUser.new
+      allow(GDS::SSO).to receive(:test_user).and_return(test_user)
 
-    # add an extra permission
-    GDS::SSO::Config.additional_mock_permissions_required = "extra_permission"
+      expect(described_class.locate("anything")).to be(test_user)
+    end
 
-    # ensure the dummy user is returned
-    expect(GDS::SSO).to receive(:test_user).and_return(dummy_user)
+    it "doesn't modify the permissions of GDS::SSO.test_user" do
+      test_user = TestUser.new(permissions: [])
+      allow(GDS::SSO).to receive(:test_user).and_return(test_user)
+      allow(GDS::SSO::Config).to receive(:permissions_for_dummy_api_user)
+        .and_return(%w[signin extra_permission])
 
-    # call .locate again...this should update our permissions
-    dummy_user_two = subject.locate("ABC")
-    expect(dummy_user_two.permissions).to match_array(%w[signin extra_permission])
+      expect(described_class.locate("anything")).to be(test_user)
+      expect(test_user.permissions).not_to include("extra_permission")
+    end
+
+    it "returns a user with dummyapiuser@domain.com if one exists" do
+      test_user = TestUser.new
+      allow(GDS::SSO::Config).to receive(:user_klass).and_return(TestUser)
+      allow(TestUser).to receive(:where).and_return([test_user])
+
+      expect(described_class.locate("anything")).to be(test_user)
+      expect(TestUser).to have_received(:where).with(email: "dummyapiuser@domain.com")
+    end
+
+    it "creates a user with dummyapiuser@domain.com if one does not exist" do
+      allow(GDS::SSO::Config).to receive(:user_klass).and_return(TestUser)
+      allow(GDS::SSO::Config).to receive(:additional_mock_permissions_required).and_return(nil)
+      allow(TestUser).to receive(:where).and_return([])
+
+      test_user = described_class.locate("anything")
+      expect(test_user).to be_an_instance_of(TestUser)
+      expect(test_user).to have_attributes(email: "dummyapiuser@domain.com",
+                                           name: "Dummy API user created by gds-sso",
+                                           permissions: %w[signin])
+    end
+
+    it "uses GDS::SSO::Config to overwrite any existing permissions" do
+      test_user = TestUser.new(permissions: %w[signin other_permission])
+      allow(GDS::SSO::Config).to receive(:user_klass).and_return(TestUser)
+      allow(TestUser).to receive(:where).and_return([test_user])
+      allow(GDS::SSO::Config).to receive(:permissions_for_dummy_api_user)
+        .and_return(%w[signin extra_permission])
+
+      test_user = described_class.locate("anything")
+      expect(test_user.permissions).to match_array(%w[signin extra_permission])
+    end
   end
 end


### PR DESCRIPTION
This removes an oddity where the config value of
additional_mock_permissions can be a bit overreaching as it was previously overriding any permissions set on GDS::SSO.test_user.

This made it very difficult to test APIs where permissions were missing as any permissions set on an existing user were overwritten when the user was located.

I've flagged this as a breaking change but I expect the consequences to be rather small as I don't imagine users expected this behaviour and thus had workflows based around it and that MockBearerToken has likely been the subject of rather low usage [1].

[1]: https://github.com/alphagov/gds-sso/pull/323

This repo is owned by the publishing access & permissions team. Please let us know in #govuk-publishing-access-and-permissions-team when you raise any PRs.
