### PR TITLE
Expand tests to include Ruby 3.4 and Rails 8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,9 +32,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [3.2, 3.3]
+        ruby: [3.2, 3.3, 3.4]
         # Support testing against multiple Rails versions
-        gemfile: [rails_7]
+        gemfile: [rails_7, rails_8]
     runs-on: ubuntu-latest
     env:
       BUNDLE_GEMFILE: gemfiles/${{ matrix.gemfile }}.gemfile

--- a/gemfiles/rails_8.gemfile
+++ b/gemfiles/rails_8.gemfile
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+
+gem "rails", "~> 8.0"
+
+gemspec path: "../"


### PR DESCRIPTION
Both of these are now commonly used.

This repo is owned by the publishing access & permissions team. Please let us know in #govuk-publishing-access-and-permissions-team when you raise any PRs.
