### PR TITLE
Update PR template to reflect application ownership

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,1 +1,1 @@
-This repo is owned by the publishing access & permissions team. Please let us know in #govuk-publishing-access-and-permissions-team when you raise any PRs.
+This repo is owned by the GOV.UK Publishing Platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.


### PR DESCRIPTION
This repo has been owned by the Publishing Platform team for some time, so updating the PR template to reflect that.