### PR TITLE
Release 21.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 21.0.0
 
 * BREAKING: Apps using api_only mode were incorrectly using a session auth when used without a bearer token (typically dev/test environments) this has been resolved and this may cause breaking workflows due to user permission differences between session and bearer token strategies. This can be resolved by configuring the `additional_mock_permissions_required` config option.
 * Adds config option for apps to enable API mode for a subset of routes. This can be enabled with an initialiser:  `GDS::SSO.config { |config| config.api_request_matcher = ->(request) { request.path.start_with?("/api/") } }`.

--- a/lib/gds-sso/version.rb
+++ b/lib/gds-sso/version.rb
@@ -1,5 +1,5 @@
 module GDS
   module SSO
-    VERSION = "20.0.0".freeze
+    VERSION = "21.0.0".freeze
   end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/lINc0yU5/2580-investigate-changing-gds-sso-so-it-can-be-api-only-for-our-api-paths

Contains:

* BREAKING: Apps using api_only mode were incorrectly using a session auth when used without a bearer token (typically dev/test environments) this has been resolved and this may cause breaking workflows due to user permission differences between session and bearer token strategies. This can be resolved by configuring the `additional_mock_permissions_required` config option.
* Adds config option for apps to enable API mode for a subset of routes. This can be enabled with an initialiser: `GDS::SSO.config { |config| config.api_request_matcher = ->(request) { request.path.start_with?("/api/") } }`.
* BREAKING: Removed deprecated GDS::SSO::ControllerMethods::PermissionDeniedException.
* BREAKING: MockBearerToken returns a specified GDS::SSO.test_user without permission modifications to allow testing different permissions
* Introduce GDS::SSO.authenticate_user! method to encapsulate the authentication code for re-use.

This repo is owned by the GOV.UK Publishing Platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.
