### PR TITLE
API only apps should have user update routes available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* Fix an issue where Signon callbacks to api_only apps weren't possible because routes weren't available.
 * Fixes usage of GDS::SSO.config.api_request_matcher blocking authentication of GDS SSO internal API. Matcher for GDS SSO API can be configured with `GDS::SSO.config { |config| config.gds_sso_api_request_matcher = ->(request) { request.path.start_with?("/custom/api") }}`
 
 ## 21.0.0

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,9 +1,10 @@
 Rails.application.routes.draw do
+  put  "/auth/gds/api/users/:uid",        to: "api/user#update"
+  post "/auth/gds/api/users/:uid/reauth", to: "api/user#reauth"
+
   next if GDS::SSO::Config.api_only
 
   get "/auth/gds/callback",               to: "authentications#callback", as: :gds_sign_in
   get "/auth/gds/sign_out",               to: "authentications#sign_out", as: :gds_sign_out
-  get  "/auth/failure",                   to: "authentications#failure",  as: :auth_failure
-  put  "/auth/gds/api/users/:uid",        to: "api/user#update"
-  post "/auth/gds/api/users/:uid/reauth", to: "api/user#reauth"
+  get "/auth/failure",                    to: "authentications#failure",  as: :auth_failure
 end


### PR DESCRIPTION
This fixes a mistake I made ~8 years ago [1] where all routes were disabled for api_only apps. Actually the /auth/gds/api results should still have been available as they are used to update users (including API users) when account permissions are updated or users are suspended. Without this any updates to a user don't take effect until after any caching expires [2] (5 mins).

Turning this on is very unlikely to impact applications at the moment as typically api only apps are configured in signon with push_updates set to off and have inaccessible host names. In order for these apps to benefit from this change they would need both of these issues resolved. My motivation to fix this is primarily about correcting the mistake I introduced to this equation.

[1]: https://github.com/alphagov/gds-sso/commit/3990387eb19a5a6a2d084194ce10a450fa3a2fa9
[2]: https://github.com/alphagov/gds-sso/blob/8864d834b78e83854db3651fffcf137c03165d85/lib/gds-sso/bearer_token.rb#L11

This repo is owned by the GOV.UK Publishing Platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.
