### PR TITLE
Support GDS_SSO_MOCK_INVALID env var for bearer token strategies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* Setting an ENV var of GDS_SSO_MOCK_INVALID causes mock bearer token auth to fail, mirroring the behaviour of the non-bearer token strategy.
 * Fix an issue where Signon callbacks to api_only apps weren't possible because routes weren't available.
 * Fixes usage of GDS::SSO.config.api_request_matcher blocking authentication of GDS SSO internal API. Matcher for GDS SSO API can be configured with `GDS::SSO.config { |config| config.gds_sso_api_request_matcher = ->(request) { request.path.start_with?("/custom/api") }}`
 

--- a/gds-sso.gemspec
+++ b/gds-sso.gemspec
@@ -37,6 +37,7 @@ Gem::Specification.new do |s|
   s.add_dependency "warden", "~> 1.2"
   s.add_dependency "warden-oauth2", "~> 0.0.1"
 
+  s.add_development_dependency "climate_control", "~> 1"
   s.add_development_dependency "combustion", "~> 1.3"
   s.add_development_dependency "rake"
   s.add_development_dependency "rspec-rails", "~> 6"

--- a/lib/gds-sso/bearer_token.rb
+++ b/lib/gds-sso/bearer_token.rb
@@ -58,6 +58,7 @@ module GDS
 
     module MockBearerToken
       def self.locate(_token_string)
+        return unless ENV["GDS_SSO_MOCK_INVALID"].to_s.empty?
         return GDS::SSO.test_user if GDS::SSO.test_user
 
         dummy_api_user = GDS::SSO::Config.user_klass.where(email: "dummyapiuser@domain.com").first

--- a/spec/request/demo_app_spec.rb
+++ b/spec/request/demo_app_spec.rb
@@ -123,12 +123,28 @@ describe "Integration tests with a demo app", type: :request do
       expect(response.body).to eq("restricted kablooie")
     end
 
+    it "can be configured to fail authentication with an env var" do
+      ClimateControl.modify("GDS_SSO_MOCK_INVALID" => "1") do
+        get "/restricted"
+        expect(response).to redirect_to("/auth/gds")
+      end
+    end
+
     it "allows an API request without a bearer token" do
       allow(GDS::SSO::Config).to receive(:api_only).and_return(true)
 
       get "/restricted"
       expect(response).to have_http_status(:success)
       expect(response.body).to eq("restricted kablooie")
+    end
+
+    it "can be configured to fail API authentication with an env var" do
+      allow(GDS::SSO::Config).to receive(:api_only).and_return(true)
+
+      ClimateControl.modify("GDS_SSO_MOCK_INVALID" => "1") do
+        get "/restricted"
+        expect(response).to have_http_status(:unauthorized)
+      end
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,7 @@
 # Bad things happen if we don't ;-)
 ENV["GDS_SSO_STRATEGY"] = "real"
 
+require "climate_control"
 require "webmock/rspec"
 require "combustion"
 

--- a/spec/unit/mock_bearer_token_spec.rb
+++ b/spec/unit/mock_bearer_token_spec.rb
@@ -10,6 +10,12 @@ describe GDS::SSO::MockBearerToken do
       expect(described_class.locate("anything")).to be(test_user)
     end
 
+    it "returns nil if ENV['GDS_SSO_MOCK_INVALID'] is set" do
+      ClimateControl.modify("GDS_SSO_MOCK_INVALID" => "1") do
+        expect(described_class.locate("anything")).to be_nil
+      end
+    end
+
     it "doesn't modify the permissions of GDS::SSO.test_user" do
       test_user = TestUser.new(permissions: [])
       allow(GDS::SSO).to receive(:test_user).and_return(test_user)


### PR DESCRIPTION
Note: this is a draft as it builds off https://github.com/alphagov/gds-sso/pull/331

---

This env var only had an effect on the non-bearer token mock strategy. This wasn't too much of a problem before #323 [1] as API apps were inadvertently using the session strategy.

Now this isn't the case, it's no longer possible to test authentication failing hence this change.

I've added the climate_control gem for setting env vars using tests and added integration tests for both bearer and non-bearer token usages.

[1]: https://github.com/alphagov/gds-sso/pull/323

This repo is owned by the GOV.UK Publishing Platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.
