### PR TITLE
Release 21.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 21.1.0
 
 * Setting an ENV var of GDS_SSO_MOCK_INVALID causes mock bearer token auth to fail, mirroring the behaviour of the non-bearer token strategy.
 * Fix an issue where Signon callbacks to api_only apps weren't possible because routes weren't available.

--- a/lib/gds-sso/version.rb
+++ b/lib/gds-sso/version.rb
@@ -1,5 +1,5 @@
 module GDS
   module SSO
-    VERSION = "21.0.0".freeze
+    VERSION = "21.1.0".freeze
   end
 end


### PR DESCRIPTION
* Setting an ENV var of GDS_SSO_MOCK_INVALID causes mock bearer token auth to fail, mirroring the behaviour of the non-bearer token strategy.
* Fix an issue where Signon callbacks to api_only apps weren't possible because routes weren't available.
* Fixes usage of GDS::SSO.config.api_request_matcher blocking authentication of GDS SSO internal API. Matcher for GDS SSO API can be configured with `GDS::SSO.config { |config| config.gds_sso_api_request_matcher = ->(request) { request.path.start_with?("/custom/api") }}`

This repo is owned by the GOV.UK Publishing Platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.
