### PR TITLE
[PP-6927] Skip `return_to` for very long paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+* BREAKING: Don't store overly long `return_to` paths in the session cookie.
+Specifically paths over 2048 bytes (2kB) which is very large and therefore
+hopefully not breaking in practice.
+
 ## 21.1.0
 
 * Setting an ENV var of GDS_SSO_MOCK_INVALID causes mock bearer token auth to fail, mirroring the behaviour of the non-bearer token strategy.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 22.0.0
 
 * BREAKING: Don't store overly long `return_to` paths in the session cookie.
 Specifically paths over 2048 bytes (2kB) which is very large and therefore

--- a/lib/gds-sso/failure_app.rb
+++ b/lib/gds-sso/failure_app.rb
@@ -6,6 +6,8 @@ require "rails"
 module GDS
   module SSO
     class FailureApp < ActionController::Metal
+      MAX_RETURN_TO_PATH_SIZE = 2048
+
       include ActionController::Redirecting
       include AbstractController::Rendering
       include ActionController::Rendering
@@ -44,7 +46,12 @@ module GDS
 
       # TOTALLY NOT DOING THE SCOPE THING. PROBABLY SHOULD.
       def store_location!
-        session["return_to"] = request.env["warden.options"][:attempted_path] if request.get?
+        return unless request.get?
+
+        attempted_path = request.env["warden.options"][:attempted_path]
+        return if attempted_path.bytesize > MAX_RETURN_TO_PATH_SIZE
+
+        session["return_to"] = attempted_path
       end
 
     private

--- a/lib/gds-sso/version.rb
+++ b/lib/gds-sso/version.rb
@@ -1,5 +1,5 @@
 module GDS
   module SSO
-    VERSION = "21.1.0".freeze
+    VERSION = "22.0.0".freeze
   end
 end

--- a/spec/unit/failure_app_spec.rb
+++ b/spec/unit/failure_app_spec.rb
@@ -1,0 +1,31 @@
+require "spec_helper"
+
+describe GDS::SSO::FailureApp, type: :request do
+  describe "#redirect" do
+    before do
+      Rails.application.routes.draw do
+        get "redirect", to: GDS::SSO::FailureApp.action(:redirect)
+      end
+    end
+
+    after { Rails.application.reload_routes! }
+
+    it "should store the return_to path in session when it is reasonably short" do
+      attempted_path = "some-reasonably-short-path"
+
+      get "/redirect", env: { "warden.options" => { attempted_path: } }
+
+      expect(response).to redirect_to("/auth/gds")
+      expect(session["return_to"]).to eq(attempted_path)
+    end
+
+    it "should not attempt to store the return_to path in session when it is very long" do
+      attempted_path = "some-#{'very-' * 1000}-long-path"
+
+      get "/redirect", env: { "warden.options" => { attempted_path: } }
+
+      expect(response).to redirect_to("/auth/gds")
+      expect(session["return_to"]).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
We sometimes get `ActionDispatch::Cookies::CookieOverflow` errors and we know that we can trigger these by trying to access a really long path before being redirected to a sign in page. In [Signon][], we found that if a full path (path plus query) was longer than 2048 bytes it would cause this error, so we're setting the same limit here. If a `return_to` path would exceed this limit, we skip storing it in the cookie. It's unlikely any genuine path would come close to this, but if it does, we think it's okay just to be redirected to root in these cases (by `AuthenticationsController#callback`)

The motivation for exploring this was session cookie overflow errors in Authenticating Proxy. We don't think these specific errors were caused by really long paths, but this change provides a useful guard nonetheless. We haven't seen the Authenticating Proxy session cookie overflows for a while, but if and when we do we should look for other places where we might store variable length values in the session cookie

[Signon]: https://github.com/alphagov/signon/pull/3963