### PR TITLE
Remove confusing 14 year old comment about scope

### DIFF
--- a/lib/gds-sso/failure_app.rb
+++ b/lib/gds-sso/failure_app.rb
@@ -37,12 +37,6 @@ module GDS
         api_unauthorized("No bearer token was provided", "invalid_request")
       end
 
-      # Stores requested uri to redirect the user after signing in. We cannot use
-      # scoped session provided by warden here, since the user is not authenticated
-      # yet, but we still need to store the uri based on scope, so different scopes
-      # would never use the same uri to redirect.
-
-      # TOTALLY NOT DOING THE SCOPE THING. PROBABLY SHOULD.
       def store_location!
         session["return_to"] = request.env["warden.options"][:attempted_path] if request.get?
       end


### PR DESCRIPTION
This BLOCK CAPITALS comment has been lingering here so long its voice has broken and its getting acne.

I've done a bit of digging, and learned that Warden (the library we use for authentication) has a concept of "scopes". You might do (in one controller):

```
authenticate_user!
```

And in another:

```
authenticate_admin!
```

And you should expect that the former will have a scope set to :user, and the latter will have a scope set to :admin

The non-block-capitals bit of the comment was copied from Devise's failure app, here:

https://github.com/heartcombo/devise/blob/cf93de390a29654620fdf7ac07b4794eb95171d0/lib/devise/failure_app.rb#L244-L250

Devise uses warden's scope to avoid the situation where the same user authenticates in two different contexts, firstly as a normal user and secondly as an admin. There's a hazard there where they could end up with their session's return_to value set by the normal user auth, but used by the admin auth (or vice versa).

I guess this is why we put a giant NOT DOING THE SCOPE THING. PROBABLY SHOULD. comment in our code 14 years ago. But realistically, I don't think it's much of a problem in our case.

Firstly, gds-sso doesn't really use warden scopes - everyone just gets authenticated as a user. So we couldn't use them without some bigger surgery.

Secondly, we check `if request.get?`, so we only put safe attempted paths in the return_to parameter.

Thirdly, we've been fine without using scope for the last 14 years, so we'll probably survive a bit longer.
