### PR TITLE
[PP-7304] Add User#anonymous_user_id and test it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 22.1.0
+
+* Add User#anonymous_user_id [#341](https://github.com/alphagov/gds-sso/pull/341)
+
 ## 22.0.0
 
 * BREAKING: Don't store overly long `return_to` paths in the session cookie.

--- a/lib/gds-sso/lint/user_spec.rb
+++ b/lib/gds-sso/lint/user_spec.rb
@@ -49,30 +49,33 @@ RSpec.shared_examples "a gds-sso user class" do
   end
 
   specify "the User class and GDS::SSO::User mixin work together" do
-    auth_hash = {
-      "uid" => "12345",
-      "info" => {
-        "name" => "Joe Smith",
-        "email" => "joe.smith@example.com",
-      },
-      "extra" => {
-        "user" => {
-          "disabled" => false,
-          "permissions" => %w[signin],
-          "organisation_slug" => "cabinet-office",
-          "organisation_content_id" => "91e57ad9-29a3-4f94-9ab4-5e9ae6d13588",
+    ClimateControl.modify ANONYMOUS_USER_ID_SECRET: "some-anonymous-user-id-secret" do
+      auth_hash = {
+        "uid" => "12345",
+        "info" => {
+          "name" => "Joe Smith",
+          "email" => "joe.smith@example.com",
         },
-      },
-    }
+        "extra" => {
+          "user" => {
+            "disabled" => false,
+            "permissions" => %w[signin],
+            "organisation_slug" => "cabinet-office",
+            "organisation_content_id" => "91e57ad9-29a3-4f94-9ab4-5e9ae6d13588",
+          },
+        },
+      }
 
-    user = described_class.find_for_gds_oauth(auth_hash)
-    expect(user).to be_an_instance_of(described_class)
-    expect(user.uid).to eq("12345")
-    expect(user.name).to eq("Joe Smith")
-    expect(user.email).to eq("joe.smith@example.com")
-    expect(user).not_to be_disabled
-    expect(user.permissions).to eq(%w[signin])
-    expect(user.organisation_slug).to eq("cabinet-office")
-    expect(user.organisation_content_id).to eq("91e57ad9-29a3-4f94-9ab4-5e9ae6d13588")
+      user = described_class.find_for_gds_oauth(auth_hash)
+      expect(user).to be_an_instance_of(described_class)
+      expect(user.uid).to eq("12345")
+      expect(user.anonymous_user_id).to eq("91f4d86cd48c6d0cf")
+      expect(user.name).to eq("Joe Smith")
+      expect(user.email).to eq("joe.smith@example.com")
+      expect(user).not_to be_disabled
+      expect(user.permissions).to eq(%w[signin])
+      expect(user.organisation_slug).to eq("cabinet-office")
+      expect(user.organisation_content_id).to eq("91e57ad9-29a3-4f94-9ab4-5e9ae6d13588")
+    end
   end
 end

--- a/lib/gds-sso/user.rb
+++ b/lib/gds-sso/user.rb
@@ -1,4 +1,5 @@
 require "active_support/concern"
+require "json"
 
 module GDS
   module SSO
@@ -37,6 +38,13 @@ module GDS
 
       def set_remotely_signed_out!
         update_attribute(:remotely_signed_out, true)
+      end
+
+      def anonymous_user_id
+        secret = ENV["ANONYMOUS_USER_ID_SECRET"]
+        return if secret.nil?
+
+        @anonymous_user_id ||= Digest::SHA2.hexdigest(JSON.dump([uid, secret]))[..16]
       end
 
       module ClassMethods

--- a/lib/gds-sso/version.rb
+++ b/lib/gds-sso/version.rb
@@ -1,5 +1,5 @@
 module GDS
   module SSO
-    VERSION = "22.0.0".freeze
+    VERSION = "22.1.0".freeze
   end
 end

--- a/spec/unit/user_spec.rb
+++ b/spec/unit/user_spec.rb
@@ -30,6 +30,26 @@ describe GDS::SSO::User do
     expect(GDS::SSO::User.user_params_from_auth_hash(@auth_hash)).to eq(expected)
   end
 
+  describe "#anonymous_user_id" do
+    it "should be nil if ANONYMOUS_USER_ID_SECRET is unset" do
+      ClimateControl.modify ANONYMOUS_USER_ID_SECRET: nil do
+        expect(TestUser.new.anonymous_user_id).to be_nil
+      end
+    end
+
+    it "should be computed based on the uid and ANONYMOUS_USER_ID_SECRET" do
+      ClimateControl.modify ANONYMOUS_USER_ID_SECRET: "some-anonymous-user-id-secret" do
+        expect("8724f603978a3adc0").to eq(TestUser.new(uid: "some-user-id").anonymous_user_id)
+        expect("69d0cf995988be2e1").to eq(TestUser.new(uid: "some-other-user-id").anonymous_user_id)
+      end
+
+      ClimateControl.modify ANONYMOUS_USER_ID_SECRET: "other-anonymous-user-id-secret" do
+        expect("297069f42a9251c64").to eq(TestUser.new(uid: "some-user-id").anonymous_user_id)
+        expect("4a3c66e26f5ec4229").to eq(TestUser.new(uid: "other-user-id").anonymous_user_id)
+      end
+    end
+  end
+
   context "making sure that the lint spec is valid" do
     let(:described_class) { TestUser }
     it_behaves_like "a gds-sso user class"


### PR DESCRIPTION
Note that the tests match the behaviour in https://github.com/alphagov/signon/pull/3992, including that given the same secret and UID, we get the same value of anonymous_user_id.

I've also added an assertion into lint/user_spec.rb, which will check that we generate consistent anonymous_user_id values for all User classes which include the module.

I've deviated ever so slightly from the implementation in signon, in that I've used `JSON.dump(stuff)` instead of `stuff.to_json`. This is just because this Gem might be used in places without rails / activesupport, so I'm not certain the .to_json method will always be there.