### PR TITLE
Set ENV naïvely if ClimateControl is unavailable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 22.1.1
+
+* Remove accidental dependency on climate_control [#342](https://github.com/alphagov/gds-sso/pull/342)
+
 ## 22.1.0
 
 * Add User#anonymous_user_id [#341](https://github.com/alphagov/gds-sso/pull/341)

--- a/lib/gds-sso/version.rb
+++ b/lib/gds-sso/version.rb
@@ -1,5 +1,5 @@
 module GDS
   module SSO
-    VERSION = "22.1.0".freeze
+    VERSION = "22.1.1".freeze
   end
 end


### PR DESCRIPTION
This means that dependent apps don't need to have climate_control in their gemfiles, but if they do they'll benefit from its more careful handling of threading / parallel tests.

This repo is owned by the GOV.UK Publishing Platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.
