### PR TITLE
[PP-7685] Update Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ updates:
       day: tuesday
       time: "07:00"
     allow:
-      - dependency-type: "all"
+      - dependency-type: direct
     cooldown:
       default-days: 3
     open-pull-requests-limit: 25

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,7 @@ updates:
       - dependency-type: "all"
     cooldown:
       default-days: 3
+    open-pull-requests-limit: 25
     groups:
       test:
         patterns:
@@ -26,3 +27,4 @@ updates:
       time: "07:00"
     cooldown:
       default-days: 3
+    open-pull-requests-limit: 25

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,9 @@ updates:
   - package-ecosystem: bundler
     directory: /
     schedule:
-    interval: daily
+      interval: weekly
+      day: tuesday
+      time: "07:00"
     allow:
       - dependency-type: "all"
     cooldown:
@@ -19,6 +21,8 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: daily
+      interval: weekly
+      day: tuesday
+      time: "07:00"
     cooldown:
       default-days: 3

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,12 +1,12 @@
 version: 2
 updates:
-- package-ecosystem: bundler
-  directory: "/"
-  schedule:
+  - package-ecosystem: bundler
+    directory: /
+    schedule:
     interval: daily
-  allow:
-    - dependency-type: "all"
-- package-ecosystem: "github-actions"
-  directory: "/"
-  schedule:
-    interval: daily
+    allow:
+      - dependency-type: "all"
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,8 @@ updates:
     interval: daily
     allow:
       - dependency-type: "all"
+    cooldown:
+      default-days: 3
     groups:
       test:
         patterns:
@@ -18,3 +20,5 @@ updates:
     directory: /
     schedule:
       interval: daily
+    cooldown:
+      default-days: 3

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,14 @@ updates:
     interval: daily
     allow:
       - dependency-type: "all"
+    groups:
+      test:
+        patterns:
+          - "capybara*"
+          - "combustion"
+          - "rspec-*"
+          - "timecop"
+
   - package-ecosystem: github-actions
     directory: /
     schedule:


### PR DESCRIPTION
This PR refines Dependabot configuration to reduce noise and improve update safety. It adds configuration for github-actions, introduces cooldown periods to avoid unstable releases, groups related Bundler updates and switches to a weekly Tuesday 7:00 UTC schedule.

It also increases the open PR limit to 25 to support batching, and restricts updates to direct dependencies only for more relevant, manageable changes.

Security updates remain unaffected and continue to be raised immediately.